### PR TITLE
Feat/97 add partner contact details

### DIFF
--- a/src/Data/TestFixtures.elm
+++ b/src/Data/TestFixtures.elm
@@ -16,24 +16,33 @@ partners =
       , summary = "Partner one Info"
       , description = "Partner one intro"
       , address = Just { postalCode = "SE1 1RB" }
+      , areasServed = []
       }
     , { id = "2"
       , name = "Partner two"
       , summary = "Partner two Info"
       , description = "Partner two intro"
       , address = Just { postalCode = "WC1N 3XX" }
+      , areasServed =
+            [ { name = "Central London", abbreviatedName = Just "Central Ldn" }
+            ]
       }
     , { id = "3"
       , name = "Partner three"
       , summary = "Partner three Info"
       , description = "Partner three intro"
       , address = Nothing
+      , areasServed =
+            [ { name = "Birmingham", abbreviatedName = Nothing }
+            , { name = "London", abbreviatedName = Nothing }
+            ]
       }
     , { id = "4"
       , name = "Partner four"
       , summary = "Partner four Info"
       , description = "Partner four intro"
       , address = Just { postalCode = "N2 2AA" }
+      , areasServed = []
       }
     ]
 

--- a/src/Page/Partners.elm
+++ b/src/Page/Partners.elm
@@ -8,7 +8,7 @@ import DataSource exposing (DataSource)
 import Head
 import Head.Seo as Seo
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
-import Html.Styled exposing (Html, a, div, h1, h2, h3, h4, img, li, p, section, span, text, ul)
+import Html.Styled exposing (Html, a, div, h1, h2, h3, h4, img, li, p, section, span, styled, text, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import Page exposing (Page, PageWithState, StaticPayload)
 import Pages.PageUrl exposing (PageUrl)
@@ -108,7 +108,7 @@ viewPartner partner =
         [ div [ css [ partnerTopRowStyle ] ]
             [ h4 [ css [ partnerNameStyle ] ]
                 [ a [ href (TransRoutes.toAbsoluteUrl (Partner partner.id)), css [ partnerNameLink ] ] [ text partner.name ] ]
-            , viewMaybePostalCode partner.address
+            , viewAreaTag partner.areasServed partner.address
             ]
         , div [ css [ partnerBottomRowStyle ] ]
             [ p [ css [ partnerDescriptionStyle ] ]
@@ -124,11 +124,41 @@ viewMap =
     div [ css [ featurePlaceholderStyle ] ] [ text "[fFf] Map" ]
 
 
+viewAreaTag :
+    List Data.PlaceCal.Partners.ServiceArea
+    -> Maybe Data.PlaceCal.Partners.Address
+    -> Html msg
+viewAreaTag serviceAreas maybeAddress =
+    if List.length serviceAreas > 0 then
+        ul []
+            (List.map
+                (\area ->
+                    li []
+                        [ partnerAreaTagSpan [] [ text (areaNameString area) ]
+                        ]
+                )
+                serviceAreas
+            )
+
+    else
+        viewMaybePostalCode maybeAddress
+
+
+areaNameString : Data.PlaceCal.Partners.ServiceArea -> String
+areaNameString serviceArea =
+    case serviceArea.abbreviatedName of
+        Just shortName ->
+            shortName
+
+        Nothing ->
+            serviceArea.name
+
+
 viewMaybePostalCode : Maybe Data.PlaceCal.Partners.Address -> Html msg
 viewMaybePostalCode maybeAddress =
     case maybeAddress of
         Just address ->
-            span [ css [ partnerTagStyle ] ]
+            partnerAreaTagSpan []
                 [ text (areaDistrictString address)
                 ]
 
@@ -141,6 +171,25 @@ areaDistrictString address =
     String.split " " address.postalCode
         |> List.head
         |> Maybe.withDefault ""
+
+
+
+--------------
+-- With Styles
+--------------
+
+
+partnerAreaTagSpan : List (Html.Styled.Attribute msg) -> List (Html msg) -> Html msg
+partnerAreaTagSpan =
+    styled span
+        [ backgroundColor darkPurple
+        , color pink
+        , display inlineBlock
+        , padding2 (rem 0.25) (rem 0.5)
+        , borderRadius (rem 0.3)
+        , fontWeight (int 600)
+        , fontSize (rem 0.877777)
+        ]
 
 
 
@@ -218,19 +267,6 @@ partnerNameLink =
     batch
         [ textDecoration none
         , color white
-        ]
-
-
-partnerTagStyle : Style
-partnerTagStyle =
-    batch
-        [ backgroundColor darkPurple
-        , color pink
-        , display inlineBlock
-        , padding2 (rem 0.25) (rem 0.5)
-        , borderRadius (rem 0.3)
-        , fontWeight (int 600)
-        , fontSize (rem 0.877777)
         ]
 
 

--- a/tests/Page/PartnerTests.elm
+++ b/tests/Page/PartnerTests.elm
@@ -21,6 +21,7 @@ viewParamsWithPartner =
         , description = "Partner description"
         , summary = "Partner summary"
         , address = Nothing
+        , areasServed = []
         }
     , path = Path.fromString "partner/1"
     , routeParams = { partner = "1" }

--- a/tests/Page/PartnersTests.elm
+++ b/tests/Page/PartnersTests.elm
@@ -54,9 +54,47 @@ suite =
         , test "Contains a list of all partners" <|
             \_ ->
                 viewBodyHtml viewParamsWithPartners
-                    |> Query.find [ Selector.tag "ul" ]
+                    |> Query.findAll [ Selector.tag "ul" ]
+                    |> Query.first
                     |> Query.children [ Selector.tag "li" ]
                     |> Query.count (Expect.equal 4)
+        , test "Displays abbreviated name of service area if exists" <|
+            \_ ->
+                viewBodyHtml viewParamsWithPartners
+                    |> Query.contains [ Html.text "Central Ldn" ]
+        , test "Displays name for service area if no abbreviated name" <|
+            \_ ->
+                viewBodyHtml viewParamsWithPartners
+                    |> Query.has [ Selector.text "Birmingham" ]
+        , test "Displays tag for all service areas" <|
+            \_ ->
+                viewBodyHtml viewParamsWithPartners
+                    |> Query.has
+                        [ Selector.tag "ul"
+                        , Selector.containing
+                            [ Selector.tag "li"
+                            , Selector.containing
+                                [ Selector.tag "span", Selector.containing [ Selector.text "Birmingham" ] ]
+                            , Selector.tag "li"
+                            , Selector.containing
+                                [ Selector.tag "span", Selector.containing [ Selector.text "London" ] ]
+                            ]
+                        ]
+        , test "Does not display name for service area if has abbreviated name" <|
+            \_ ->
+                viewBodyHtml viewParamsWithPartners
+                    |> Query.hasNot [ Selector.text "Central London" ]
+        , test "Displays postal code if no service area" <|
+            \_ ->
+                viewBodyHtml viewParamsWithPartners
+                    |> Query.has
+                        [ Selector.tag "li"
+                        , Selector.containing [ Selector.text "SE1" ]
+                        ]
+        , test "Does not display postal code if has service area" <|
+            \_ ->
+                viewBodyHtml viewParamsWithPartners
+                    |> Query.hasNot [ Selector.text "WC1N" ]
         , test "Does not contain list if there are no partners" <|
             \_ ->
                 viewBodyHtml viewParamsWithoutPartners


### PR DESCRIPTION
Fixes #97

## Description

- Add service area tag(s) as abbreviated or name if they exist on a partner in partners listing page
- Add fist half of postcode if no servie area exists on a partner in the partners listing page

NOTE: There is a bug issue logged in PlaceCal for data standard https://github.com/geeksforsocialchange/PlaceCal/issues/1079