### PR TITLE
fix: Remove comic relief maker. Add unstyled logos to footer & about

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -29,27 +29,21 @@ We have tried to design this website to be as usable as possible. If you think t
 
 ## Meet the Makers
 
-* ![Geeks for social change logo](/images/gfsclogo.svg) Geeks for Social Change is a trans and disabled led research and development studio based in Manchester, UK.
+* ![Geeks for social change logo](/images/logos/TDD_About_GFSC_White.svg) Geeks for Social Change is a trans and disabled led research and development studio based in Manchester, UK.
 
     We work in collaboration with people, organisations and communities to deliver tools, training and support for lasting and holistic change. We specialise in working with difficult social problems.
 
      [Visit gfsc.studio](https://gfsc.studio)
 
-* ![gendered intelligence logo](/images/gilogo.svg) Gendered Intelligence is a registered charity that exists to increase understanding of gender diversity and improve trans people's quality of life.
+* ![gendered intelligence logo](/images/logos/GI_white.png) Gendered Intelligence is a registered charity that exists to increase understanding of gender diversity and improve trans people's quality of life.
 
      GI are a trans-led and trans-involving grassroots organisation with a wealth of lived experience and community connections.
 
      [Visit genderedintelligence.co.uk](https://genderedintelligence.co.uk)
 
-* ![Comic Relief logo](/images/comicrelieflogo.svg) Comic Relief's Tech For Good scheme offers grant funding opportunities for UK social tech projects, aiming to support them in their digital journeys.
-
-    They are committed to building the social tech ecosystem, and aim to fund work that uses technology as a tool for social change. They support work that is developed with user needs at its heart — working alongside them to design the solution that will meet their needs.
-
-    [Visit comicrelief.com](https://www.comicrelief.com)
-
 ## Built Using PlaceCal
 
-### ![Placecal logo](/images/placecallogo.svg) PlaceCal
+### ![Placecal logo](/images/logos/TDD_About_PlaceCal.svg) PlaceCal
 
 PlaceCal is a package of software and training developed by Geeks for Social Change.
 

--- a/src/Theme/PageFooter.elm
+++ b/src/Theme/PageFooter.elm
@@ -44,7 +44,7 @@ viewPageFooter =
 
 viewPageFooterLogo : Html msg
 viewPageFooterLogo =
-    div [ css [ footerLogoStyle ] ] [ img [ src "/images/logos/tdd_logo_footer.svg", css [ footerLogoImageStyle ] ] [] ]
+    div [ css [ footerLogoStyle ] ] [ img [ src "/images/logos/TDD_Logo_Footer.svg", css [ footerLogoImageStyle ] ] [] ]
 
 
 viewPageFooterNavigation : Html msg


### PR DESCRIPTION
Fixes #116
Fixes #100

## Description

- Remove Comic Relief section from makers on about
- Correct logo paths on about & footer

NOTE: Assumes styling of logos will be part of #144