### PR TITLE
Feat/181 add partner info to event

### DIFF
--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -9,7 +9,6 @@ import OptimizedDecoder
 import OptimizedDecoder.Pipeline
 import Pages.Secrets
 import Time
-import Data.PlaceCal.Partners exposing (Contact)
 
 
 type alias Event =
@@ -29,8 +28,14 @@ type alias Event =
 type alias EventPartner =
     { name : Maybe String
     , id : String
-    , contactDetails : Contact
+    , maybeContactDetails : Maybe EventPartnerContact
     , maybeUrl : Maybe String
+    }
+
+
+type alias EventPartnerContact =
+    { email : String
+    , telephone : String
     }
 
 
@@ -47,9 +52,9 @@ emptyEvent =
     -- , realm = Offline
     , partner =
         { name = Nothing
-        , id = "" 
+        , id = ""
         , maybeUrl = Nothing
-        , contactDetails = { email = "", telephone = "" }
+        , maybeContactDetails = Nothing
         }
     }
 
@@ -137,7 +142,7 @@ decode =
 partnerIdDecoder : OptimizedDecoder.Decoder EventPartner
 partnerIdDecoder =
     OptimizedDecoder.string
-        |> OptimizedDecoder.map (\partnerId -> { name = Nothing, id = partnerId })
+        |> OptimizedDecoder.map (\partnerId -> { name = Nothing, id = partnerId, maybeContactDetails = Nothing, maybeUrl = Nothing })
 
 
 type alias AllEventsResponse =

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -1,6 +1,7 @@
-module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, emptyPartner, partnerNameFromId, partnerNamesFromIds, partnersData)
+module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, emptyPartner, eventPartnerFromId, partnerNameFromId, partnerNamesFromIds, partnersData)
 
 import Api
+import Data.PlaceCal.Events exposing (EventPartner)
 import DataSource
 import DataSource.Http
 import Json.Encode
@@ -153,3 +154,18 @@ partnerNamesFromIds partnerList idList =
     -- If the partner isn't in our sites partners, it won't be in the list
     List.filter (\partner -> List.member partner.id idList) partnerList
         |> List.map (\partner -> partner.name)
+
+
+eventPartnerFromId : List Partner -> String -> EventPartner
+eventPartnerFromId partnerList partnerId =
+    List.filter (\partner -> partner.id == partnerId) partnerList
+        |> List.map
+            (\partner ->
+                { name = Just partner.name
+                , maybeContactDetails = Just partner.contactDetails
+                , id = partner.id
+                , maybeUrl = partner.maybeUrl
+                }
+            )
+        |> List.head
+        |> Maybe.withDefault { name = Nothing, maybeContactDetails = Nothing, maybeUrl = Nothing, id = partnerId }

--- a/src/Data/TestFixtures.elm
+++ b/src/Data/TestFixtures.elm
@@ -83,7 +83,7 @@ events =
       , location = "Venue"
 
       --, realm = Online
-      , partner = { id = "1", name = Just "Partner one" }
+      , partner = { id = "1", name = Just "Partner one", maybeUrl = Nothing, maybeContactDetails = Nothing }
       }
     , { id = "2"
       , name = "Event 2 name"
@@ -94,7 +94,7 @@ events =
       , location = "Venue"
 
       --, realm = Offline
-      , partner = { id = "2", name = Just "Partner two" }
+      , partner = { id = "2", name = Just "Partner two", maybeUrl = Nothing, maybeContactDetails = Nothing }
       }
     ]
 

--- a/tests/Page/EventTests.elm
+++ b/tests/Page/EventTests.elm
@@ -24,7 +24,7 @@ viewParamsWithEvent =
         , location = "Event location"
 
         --, realm = Online
-        , partner = { id = "1", name = Just "Partner one" }
+        , partner = { id = "1", name = Just "Partner one", maybeContactDetails = Just { telephone = "999", email = "partner@partner.com" }, maybeUrl = Just "https://google.com" }
         }
     , path = Path.fromString "event/1"
     , routeParams = { event = "1" }

--- a/tests/Page/PartnerTests.elm
+++ b/tests/Page/PartnerTests.elm
@@ -42,7 +42,7 @@ viewParamsWithPartner =
               , startDatetime = Time.millisToPosix 1645466400000
               , endDatetime = Time.millisToPosix 1650564000000
               , location = "Venue"
-              , partner = { id = "1", name = Nothing }
+              , partner = { id = "1", name = Nothing, maybeUrl = Nothing, maybeContactDetails = Nothing }
               }
             , { id = "2"
               , name = "Event 2 name"
@@ -51,7 +51,7 @@ viewParamsWithPartner =
               , startDatetime = Time.millisToPosix 1645448400000
               , endDatetime = Time.millisToPosix 1658408400000
               , location = "Venue"
-              , partner = { id = "1", name = Nothing }
+              , partner = { id = "1", name = Nothing, maybeUrl = Nothing, maybeContactDetails = Nothing }
               }
             ]
         }


### PR DESCRIPTION
Fixes #181

## Description

- Think this does the job?
- Contact info for partner displaying on event page
- We probably need a state for 'no partner contact info' for both Partner and Event single pages but I'd need to double check what format the data's coming in on to be able to test for it