### PR TITLE
Temporarily set canonical url to staging

### DIFF
--- a/src/Site.elm
+++ b/src/Site.elm
@@ -18,7 +18,7 @@ type alias Data =
 config : SiteConfig Data
 config =
     { data = data
-    , canonicalUrl = "https://transdimension.uk/"
+    , canonicalUrl = "https://transdimension.netlify.app/"
     , manifest = manifest
     , head = head
     }


### PR DESCRIPTION
Temp #247

## Description

- Until we go live on transdimension.uk, our canonical is the netlify staging site