### PR TITLE
Import events from 1 April. Display from today by default.

### DIFF
--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), emptyEvent, eventsData, eventsFromPartnerId)
+module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), emptyEvent, eventsData, eventsFromDate, eventsFromPartnerId)
 
 import Api
 import DataSource
@@ -82,6 +82,15 @@ eventsFromPartnerId eventsList id =
     List.filter (\event -> event.partner.id == id) eventsList
 
 
+eventsFromDate : List Event -> Time.Posix -> List Event
+eventsFromDate eventsList fromDate =
+    List.filter
+        (\event ->
+            TransDate.isSameDay event.startDatetime fromDate
+        )
+        eventsList
+
+
 
 ----------------------------
 -- DataSource query & decode
@@ -98,8 +107,9 @@ allEventsQuery : Json.Encode.Value
 allEventsQuery =
     Json.Encode.object
         [ ( "query"
+            -- Note hardcoded to load events from 2022-04-01
           , Json.Encode.string """
-            query { eventsByFilter(tagId: 3) {
+            query { eventsByFilter(tagId: 3, fromDate: "2022-04-01 00:00") {
               id
               name
               summary

--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -80,11 +80,7 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
             ( { localModel
                 | filterByDay = Just posix
                 , visibleEvents =
-                    List.filter
-                        (\event ->
-                            TransDate.isSameDay event.startDatetime posix
-                        )
-                        static.data
+                    Data.PlaceCal.Events.eventsFromDate static.data posix
               }
             , Cmd.none
             )
@@ -98,7 +94,14 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
             )
 
         GetTime newTime ->
-            ( { localModel | nowTime = newTime }, Cmd.none )
+            ( { localModel
+                | filterByDay = Just newTime
+                , nowTime = newTime
+                , visibleEvents =
+                    Data.PlaceCal.Events.eventsFromDate static.data newTime
+              }
+            , Cmd.none
+            )
 
         ScrollRight ->
             ( localModel


### PR DESCRIPTION
Fixes #249

## Description

- Imports events from 1 Apr 2022 onwards
- Defaults paginated page with Today preselected

**Still to do** for a more complete fix now that we import events from before today: #206 & #215