### PR TITLE
fix: Only display partner list in article header if there is one

### DIFF
--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -142,9 +142,12 @@ viewNewsArticle newsItem =
         , div [ css [ newsItemInfoStyle ] ]
             [ h3 [ css [ newsItemTitleStyle ] ] [ text newsItem.title ]
             , p [ css [ newsItemMetaStyle ] ]
-                [ span [ css [ newsItemAuthorStyle ] ]
-                    [ text (String.join ", " newsItem.partnerIds)
-                    ]
+                [ if List.length newsItem.partnerIds > 0 then
+                    span [ css [ newsItemAuthorStyle ] ]
+                        [ text (String.join ", " newsItem.partnerIds) ]
+
+                  else
+                    text ""
                 , time [] [ text (TransDate.humanDateFromPosix newsItem.publishedDatetime) ]
                 ]
             , p [ css [ newsItemSummaryStyle ] ] [ text (summaryFromArticleBody newsItem.body), text "..." ]

--- a/src/Page/News/NewsItem_.elm
+++ b/src/Page/News/NewsItem_.elm
@@ -119,8 +119,12 @@ viewArticle : Data.PlaceCal.Articles.Article -> Html Msg
 viewArticle newsItem =
     article [ css [ articleStyle ] ]
         [ p [ css [ articleMetaStyle ] ]
-            [ span [ css [ newsItemAuthorStyle ] ]
-                [ text (String.join ", " newsItem.partnerIds) ]
+            [ if List.length newsItem.partnerIds > 0 then
+                span [ css [ newsItemAuthorStyle ] ]
+                    [ text (String.join ", " newsItem.partnerIds) ]
+
+              else
+                text ""
             , time [] [ text (TransDate.humanDateFromPosix newsItem.publishedDatetime) ]
             ]
         , figure [ css [ articleFigureStyle ] ]


### PR DESCRIPTION
Fixes #202

## Description

- List bullet does not appear if there are no partners affiliated with an article
