### PR TITLE
Partner page layout tweaks

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -76,6 +76,7 @@ type Key
     | PartnerContactsHeading
     | PartnerAddressHeading
     | PartnerAddressEmptyText
+    | PartnerDescriptionText String String
     | PartnerUpcomingEventsText String
     | PartnerEventsEmptyText String
     | BackToPartnersLinkText

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -1,7 +1,6 @@
-module Copy.Text exposing (partnerDescriptionText, t, urlToDisplay)
+module Copy.Text exposing (t, urlToDisplay)
 
 import Copy.Keys exposing (Key(..))
-import Data.PlaceCal.Partners exposing (Partner)
 import Url
 
 
@@ -349,12 +348,3 @@ chompTrailingUrlSlash urlString =
 urlToDisplay : String -> String
 urlToDisplay url =
     Url.fromString url |> urlRecombiner |> chompTrailingUrlSlash
-
-
-partnerDescriptionText : Partner -> String
-partnerDescriptionText partner =
-    if String.isEmpty partner.description then
-        "Please ask " ++ partner.name ++ " for more information"
-
-    else
-        partner.description

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -1,6 +1,7 @@
-module Copy.Text exposing (t, urlToDisplay)
+module Copy.Text exposing (partnerDescriptionText, t, urlToDisplay)
 
 import Copy.Keys exposing (Key(..))
+import Data.PlaceCal.Partners exposing (Partner)
 import Url
 
 
@@ -341,3 +342,12 @@ chompTrailingUrlSlash urlString =
 urlToDisplay : String -> String
 urlToDisplay url =
     Url.fromString url |> urlRecombiner |> chompTrailingUrlSlash
+
+
+partnerDescriptionText : Partner -> String
+partnerDescriptionText partner =
+    if String.isEmpty partner.description then
+        "Please ask " ++ partner.name ++ " for more information"
+
+    else
+        partner.description

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -221,6 +221,13 @@ t key =
         PartnerAddressEmptyText ->
             "No address provided"
 
+        PartnerDescriptionText partnerDescription partnerName ->
+            if String.isEmpty partnerDescription then
+                "Please ask " ++ partnerName ++ " for more information"
+
+            else
+                partnerDescription
+
         PartnerUpcomingEventsText partnerName ->
             "Upcoming events by " ++ partnerName
 

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -1,7 +1,7 @@
 module Page.Partners.Partner_ exposing (Data, Model, Msg, page, view)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (partnerDescriptionText, t)
+import Copy.Text exposing (t)
 import Css exposing (Style, auto, batch, calc, center, color, displayFlex, fontStyle, height, important, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, pct, property, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -116,7 +116,7 @@ view maybeUrl sharedModel static =
 viewInfo : Data -> Html msg
 viewInfo { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
-        [ div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (partnerDescriptionText partner))
+        [ div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (t (PartnerDescriptionText partner.description partner.name)))
         , hr [ css [ hrStyle ] ] []
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -113,10 +113,19 @@ view maybeUrl sharedModel static =
     }
 
 
+descriptionText : Data.PlaceCal.Partners.Partner -> String
+descriptionText partner =
+    if String.isEmpty partner.description then
+        "Please ask " ++ partner.name ++ " for more information"
+
+    else
+        partner.description
+
+
 viewInfo : Data -> Html msg
 viewInfo { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
-        [ div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml partner.description)
+        [ div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (descriptionText partner))
         , hr [ css [ hrStyle ] ] []
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -205,11 +205,11 @@ descriptionStyle =
     batch
         [ normalFirstParagraphStyle
         , withMediaTabletLandscapeUp
-            [ margin2 (rem 0) auto
+            [ margin2 (rem 2) auto
             , maxWidth (px 636)
             ]
         , withMediaTabletPortraitUp
-            [ margin2 (rem 0) (rem 2) ]
+            [ margin2 (rem 2) (rem 2) ]
         ]
 
 

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -1,7 +1,7 @@
 module Page.Partners.Partner_ exposing (Data, Model, Msg, page, view)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (t)
+import Copy.Text exposing (partnerDescriptionText, t)
 import Css exposing (Style, auto, batch, calc, center, color, displayFlex, fontStyle, height, important, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, pct, property, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -113,19 +113,10 @@ view maybeUrl sharedModel static =
     }
 
 
-descriptionText : Data.PlaceCal.Partners.Partner -> String
-descriptionText partner =
-    if String.isEmpty partner.description then
-        "Please ask " ++ partner.name ++ " for more information"
-
-    else
-        partner.description
-
-
 viewInfo : Data -> Html msg
 viewInfo { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
-        [ div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (descriptionText partner))
+        [ div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (partnerDescriptionText partner))
         , hr [ css [ hrStyle ] ] []
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]


### PR DESCRIPTION
Fixes #280

## Description
On partner show page

- default text when missing partner description
- padding above description
