### PR TITLE
News item images

### DIFF
--- a/src/Data/PlaceCal/Articles.elm
+++ b/src/Data/PlaceCal/Articles.elm
@@ -16,6 +16,7 @@ type alias Article =
     , body : String
     , publishedDatetime : Time.Posix
     , partnerIds : List String
+    , maybeImage : Maybe String
     }
 
 
@@ -25,6 +26,7 @@ emptyArticle =
     , body = ""
     , publishedDatetime = Time.millisToPosix 0
     , partnerIds = []
+    , maybeImage = Nothing
     }
 
 
@@ -51,6 +53,7 @@ allArticlesQuery =
                   datePublished
                   headline
                   providers { id }
+                  image
             } } } }
             """
           )
@@ -83,6 +86,8 @@ decode =
             TransDate.isoDateStringDecoder
         |> OptimizedDecoder.Pipeline.requiredAt [ "node", "providers" ]
             (OptimizedDecoder.list partnerIdDecoder)
+        |> OptimizedDecoder.Pipeline.optionalAt [ "node", "image" ]
+            (OptimizedDecoder.nullable OptimizedDecoder.string) Nothing
 
 
 partnerIdDecoder : OptimizedDecoder.Decoder String

--- a/src/Data/PlaceCal/Articles.elm
+++ b/src/Data/PlaceCal/Articles.elm
@@ -87,7 +87,8 @@ decode =
         |> OptimizedDecoder.Pipeline.requiredAt [ "node", "providers" ]
             (OptimizedDecoder.list partnerIdDecoder)
         |> OptimizedDecoder.Pipeline.optionalAt [ "node", "image" ]
-            (OptimizedDecoder.nullable OptimizedDecoder.string) Nothing
+            (OptimizedDecoder.nullable OptimizedDecoder.string)
+            Nothing
 
 
 partnerIdDecoder : OptimizedDecoder.Decoder String

--- a/src/Data/TestFixtures.elm
+++ b/src/Data/TestFixtures.elm
@@ -117,10 +117,12 @@ news =
       , body = "Integer et nibh porta, pellentesque lacus sit amet, condimentum ligula. Praesent eget lobortis felis, id hendrerit nisl. Vivamus porttitor purus vulputate arcu consequat, vitae condimentum metus molestie. Sed ac consequat eros, vel venenatis metus. Duis laoreet id velit sit amet semper. Nunc placerat risus mi, vitae lacinia lectus rutrum sed. Sed turpis ligula, interdum eu tempor vel, accumsan in arcu. Donec hendrerit molestie sapien, sed suscipit augue. Curabitur eleifend felis magna, nec egestas eros auctor ac. Mauris hendrerit venenatis vestibulum. Aliquam erat volutpat. Aenean commodo gravida est ac dapibus. Vivamus eu lacus sit amet quam sodales consequat. Nullam auctor lacus ac imperdiet fermentum. Pellentesque vel interdum nisi. Aenean malesuada ut nunc eu euismod."
       , publishedDatetime = Time.millisToPosix 1645449400000
       , partnerIds = [ "Article Author1" ]
+      , maybeImage = Nothing
       }
     , { title = "Big news!"
       , body = "Nunc augue erat, ullamcorper et nunc nec, placerat rhoncus nulla. Quisque nec sollicitudin turpis. Etiam risus dolor, ullamcorper vitae consectetur et, faucibus a nunc. Phasellus tempus tellus ligula, dignissim bibendum leo accumsan ac. Phasellus sit amet odio varius augue aliquet venenatis. Vestibulum sit amet mi pulvinar, efficitur tortor non, semper ipsum. In ut faucibus sapien, non pellentesque odio. Morbi orci purus, consequat ut enim non, placerat eleifend neque. Nulla non rhoncus velit. Ut tristique cursus nulla vel consectetur. Fusce in odio vel nunc iaculis pulvinar. Suspendisse a sagittis orci, rutrum mattis justo.\n\n"
       , publishedDatetime = Time.millisToPosix 1645559400000
       , partnerIds = [ "Article Author1", "Article Author2" ]
+      , maybeImage = Nothing
       }
     ]

--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -127,18 +127,7 @@ viewNewsItem newsItem =
 viewNewsArticle : Data.PlaceCal.Articles.Article -> Html msg
 viewNewsArticle newsItem =
     article [ css [ newsItemArticleStyle ] ]
-        [ img
-            [ src
-                (case Array.get 0 defaultNewsImages of
-                    Just string ->
-                        string
-
-                    Nothing ->
-                        ""
-                )
-            , css [ newsImageStyle ]
-            ]
-            []
+        [ newsArticleImage newsItem.maybeImage
         , div [ css [ newsItemInfoStyle ] ]
             [ h3 [ css [ newsItemTitleStyle ] ] [ text newsItem.title ]
             , p [ css [ newsItemMetaStyle ] ]
@@ -171,7 +160,13 @@ summaryFromArticleBody articleBody =
         |> List.take 20
         |> String.join " "
 
+newsArticleImage : Maybe String -> Html msg
+newsArticleImage maybeImage =
+    let
+        imageSource = Maybe.withDefault "/images/news/article_1.jpg" maybeImage
 
+    in
+        img [ src imageSource, css [ newsImageStyle ] ] []
 
 ---------
 -- Styles
@@ -261,3 +256,10 @@ newsItemSummaryStyle =
         , marginTop (rem 0.5)
         , withMediaTabletPortraitUp [ textAlign left, fontSize (rem 1.2) ]
         ]
+
+newsItemImageStyle : Style
+newsItemImageStyle =
+    batch
+        []
+
+

--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -11,7 +11,7 @@ import Head
 import Helpers.TransDate as TransDate
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, div, h3, img, li, p, section, span, text, time, ul)
-import Html.Styled.Attributes exposing (css, href, src)
+import Html.Styled.Attributes exposing (alt, css, href, src)
 import Page exposing (Page, StaticPayload)
 import Pages.PageUrl exposing (PageUrl)
 import Shared
@@ -167,7 +167,7 @@ newsArticleImage maybeImage =
         imageSource =
             Maybe.withDefault "/images/news/article_1.jpg" maybeImage
     in
-    img [ src imageSource, css [ newsImageStyle ] ] []
+    img [ src imageSource, css [ newsImageStyle ], alt "" ] []
 
 
 
@@ -259,9 +259,3 @@ newsItemSummaryStyle =
         , marginTop (rem 0.5)
         , withMediaTabletPortraitUp [ textAlign left, fontSize (rem 1.2) ]
         ]
-
-
-newsItemImageStyle : Style
-newsItemImageStyle =
-    batch
-        []

--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -160,13 +160,16 @@ summaryFromArticleBody articleBody =
         |> List.take 20
         |> String.join " "
 
+
 newsArticleImage : Maybe String -> Html msg
 newsArticleImage maybeImage =
     let
-        imageSource = Maybe.withDefault "/images/news/article_1.jpg" maybeImage
-
+        imageSource =
+            Maybe.withDefault "/images/news/article_1.jpg" maybeImage
     in
-        img [ src imageSource, css [ newsImageStyle ] ] []
+    img [ src imageSource, css [ newsImageStyle ] ] []
+
+
 
 ---------
 -- Styles
@@ -257,9 +260,8 @@ newsItemSummaryStyle =
         , withMediaTabletPortraitUp [ textAlign left, fontSize (rem 1.2) ]
         ]
 
+
 newsItemImageStyle : Style
 newsItemImageStyle =
     batch
         []
-
-

--- a/src/Page/News/NewsItem_.elm
+++ b/src/Page/News/NewsItem_.elm
@@ -136,17 +136,15 @@ articleImage : Maybe String -> Html Msg
 articleImage maybeImageUrl =
     let
         imageSource =
-          Maybe.withDefault "/images/news/article_6.jpg" maybeImageUrl
-
+            Maybe.withDefault "/images/news/article_6.jpg" maybeImageUrl
     in
-        figure [ css [ articleFigureStyle ] ]
-          [ img [ src imageSource, css [ articleFigureImageStyle ] ] []
-          ]
+    figure [ css [ articleFigureStyle ] ]
+        [ img [ src imageSource, css [ articleFigureImageStyle ] ] []
+        ]
 
 
-    -- [fFf] , figcaption [ css [ articleFigureCaptionStyle ] ] [ text "Optional image credit, note and or details." ]
 
-
+-- [fFf] , figcaption [ css [ articleFigureCaptionStyle ] ] [ text "Optional image credit, note and or details." ]
 
 
 viewPagination : Html Msg
@@ -194,6 +192,8 @@ articleFigureImageStyle =
         , borderRadius (rem 0.3)
         ]
 
+
+
 {- not in use
    articleFigureCaptionStyle : Style
    articleFigureCaptionStyle =
@@ -228,4 +228,3 @@ newsItemAuthorStyle =
     batch
         [ after [ property "content" "\"•\"", margin2 (rem 0) (rem 0.25) ]
         ]
-

--- a/src/Page/News/NewsItem_.elm
+++ b/src/Page/News/NewsItem_.elm
@@ -127,13 +127,26 @@ viewArticle newsItem =
                 text ""
             , time [] [ text (TransDate.humanDateFromPosix newsItem.publishedDatetime) ]
             ]
-        , figure [ css [ articleFigureStyle ] ]
-            [ img [ src "/images/news/article_6.jpg", css [ articleFigureImageStyle ] ] []
-
-            -- [fFf] , figcaption [ css [ articleFigureCaptionStyle ] ] [ text "Optional image credit, note and or details." ]
-            ]
+        , articleImage newsItem.maybeImage
         , div [ css [ articleContentStyle ] ] [ text newsItem.body ]
         ]
+
+
+articleImage : Maybe String -> Html Msg
+articleImage maybeImageUrl =
+    let
+        imageSource =
+          Maybe.withDefault "/images/news/article_6.jpg" maybeImageUrl
+
+    in
+        figure [ css [ articleFigureStyle ] ]
+          [ img [ src imageSource, css [ articleFigureImageStyle ] ] []
+          ]
+
+
+    -- [fFf] , figcaption [ css [ articleFigureCaptionStyle ] ] [ text "Optional image credit, note and or details." ]
+
+
 
 
 viewPagination : Html Msg
@@ -181,8 +194,6 @@ articleFigureImageStyle =
         , borderRadius (rem 0.3)
         ]
 
-
-
 {- not in use
    articleFigureCaptionStyle : Style
    articleFigureCaptionStyle =
@@ -217,3 +228,4 @@ newsItemAuthorStyle =
     batch
         [ after [ property "content" "\"•\"", margin2 (rem 0) (rem 0.25) ]
         ]
+

--- a/src/Page/News/NewsItem_.elm
+++ b/src/Page/News/NewsItem_.elm
@@ -11,7 +11,7 @@ import Head
 import Helpers.TransDate as TransDate
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, article, div, figcaption, figure, img, p, span, text, time)
-import Html.Styled.Attributes exposing (css, src)
+import Html.Styled.Attributes exposing (alt, css, src)
 import Page exposing (Page, StaticPayload)
 import Pages.PageUrl exposing (PageUrl)
 import Shared
@@ -139,12 +139,8 @@ articleImage maybeImageUrl =
             Maybe.withDefault "/images/news/article_6.jpg" maybeImageUrl
     in
     figure [ css [ articleFigureStyle ] ]
-        [ img [ src imageSource, css [ articleFigureImageStyle ] ] []
+        [ img [ src imageSource, css [ articleFigureImageStyle ], alt "" ] []
         ]
-
-
-
--- [fFf] , figcaption [ css [ articleFigureCaptionStyle ] ] [ text "Optional image credit, note and or details." ]
 
 
 viewPagination : Html Msg

--- a/tests/Page/NewsItemTests.elm
+++ b/tests/Page/NewsItemTests.elm
@@ -21,6 +21,7 @@ viewParamsWithNewsItem =
         , body = "The news item body. Some more lines about news."
         , publishedDatetime = Time.millisToPosix 5140800000
         , partnerIds = [ "Article Author" ]
+        , maybeImage = Nothing
         }
     , path = Path.fromString "news/news-item-title"
     , routeParams = { newsItem = "news-item-title" }


### PR DESCRIPTION
Fixes #137

## Description

News items have images that come from PC API. (or filler image if none present). Work done to news data, index and show code files
