### PR TITLE
Feature: Partner google map link

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -9,6 +9,8 @@ type Key
     | PageMetaTitle String
     | GeeksForSocialChangeHomeUrl
     | GenderedIntelligenceHomeUrl
+    | GoogleMapSearchUrl String
+    | SeeOnGoogleMapText
       --- Header
     | HeaderMobileMenuButton
     | HeaderAskButton
@@ -84,7 +86,6 @@ type Key
     | PartnerUpcomingEventsText String
     | PartnerEventsEmptyText String
     | BackToPartnersLinkText
-    | SeeOnGoogleMapText
       --- Join Us Page
     | JoinUsTitle
     | JoinUsMetaDescription

--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -84,6 +84,7 @@ type Key
     | PartnerUpcomingEventsText String
     | PartnerEventsEmptyText String
     | BackToPartnersLinkText
+    | SeeOnGoogleMapText
       --- Join Us Page
     | JoinUsTitle
     | JoinUsMetaDescription

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -1,4 +1,4 @@
-module Copy.Text exposing (t, urlToDisplay)
+module Copy.Text exposing (isValidUrl, t, urlToDisplay)
 
 import Copy.Keys exposing (Key(..))
 import Url
@@ -200,6 +200,9 @@ t key =
 
         BackToEventsLinkText ->
             "Go to all events"
+
+        BackToPartnerEventsLinkText partnerName ->
+            "All events by " ++ Maybe.withDefault "this partner" partnerName
 
         --- Partners Page
         PartnersTitle ->

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -1,4 +1,4 @@
-module Copy.Text exposing (isValidUrl, t, urlToDisplay)
+module Copy.Text exposing (googleMapSearchUrl, isValidUrl, t, urlToDisplay)
 
 import Copy.Keys exposing (Key(..))
 import Url
@@ -192,11 +192,8 @@ t key =
         EventMetaDescription eventName eventSummary ->
             eventName ++ " - " ++ eventSummary
 
-        BackToPartnerEventsLinkText partnerName ->
-            "All events by " ++ Maybe.withDefault "this partner" partnerName
-
         BackToEventsLinkText ->
-            "All events"
+            "Go to all events"
 
         --- Partners Page
         PartnersTitle ->
@@ -358,6 +355,11 @@ chompTrailingUrlSlash urlString =
 urlToDisplay : String -> String
 urlToDisplay url =
     Url.fromString url |> urlRecombiner |> chompTrailingUrlSlash
+
+
+googleMapSearchUrl : String -> String
+googleMapSearchUrl address =
+    "https://www.google.com/maps/search/?api=1&query=" ++ Url.percentEncode address
 
 
 isValidUrl : String -> Bool

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -363,6 +363,11 @@ urlToDisplay url =
     Url.fromString url |> urlRecombiner |> chompTrailingUrlSlash
 
 
-googleMapSearchUrl : String -> String
-googleMapSearchUrl address =
-    "https://www.google.com/maps/search/?api=1&query=" ++ Url.percentEncode address
+isValidUrl : String -> Bool
+isValidUrl urlString =
+    case Url.fromString urlString of
+        Just url ->
+            url.protocol == Url.Https
+
+        Nothing ->
+            False

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -1,4 +1,4 @@
-module Copy.Text exposing (googleMapSearchUrl, isValidUrl, t, urlToDisplay)
+module Copy.Text exposing (t, urlToDisplay)
 
 import Copy.Keys exposing (Key(..))
 import Url
@@ -30,6 +30,12 @@ t key =
 
         GenderedIntelligenceHomeUrl ->
             "https://genderedintelligence.co.uk/"
+
+        GoogleMapSearchUrl address ->
+            "https://www.google.com/maps/search/?api=1&query=" ++ Url.percentEncode address
+
+        SeeOnGoogleMapText ->
+            "See on Google map"
 
         PageMetaTitle pageTitle ->
             String.join " | " [ pageTitle, t SiteTitle ]
@@ -360,13 +366,3 @@ urlToDisplay url =
 googleMapSearchUrl : String -> String
 googleMapSearchUrl address =
     "https://www.google.com/maps/search/?api=1&query=" ++ Url.percentEncode address
-
-
-isValidUrl : String -> Bool
-isValidUrl urlString =
-    case Url.fromString urlString of
-        Just url ->
-            url.protocol == Url.Https
-
-        Nothing ->
-            False

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -1,7 +1,7 @@
 module Page.Partners.Partner_ exposing (Data, Model, Msg, page, view)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (isValidUrl, t)
+import Copy.Text exposing (googleMapSearchUrl, isValidUrl, t)
 import Css exposing (Style, auto, batch, calc, center, color, display, displayFlex, fontStyle, height, important, inlineBlock, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, paddingTop, pct, property, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -173,11 +173,7 @@ viewContactDetails maybeUrl contactDetails =
             text ""
         , case maybeUrl of
             Just url ->
-                if isValidUrl url then
-                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
-
-                else
-                    text ""
+                p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
 
             Nothing ->
                 text ""
@@ -203,17 +199,13 @@ partnerLogo : Maybe String -> String -> Html msg
 partnerLogo maybeLogoUrl partnerName =
     case maybeLogoUrl of
         Just logoUrl ->
-            if isValidUrl logoUrl then
-                div [ css [ partnerLogoContainer ] ]
-                    [ img [ src logoUrl, css [ partnerLogoStyle ], alt (partnerName ++ " logo") ] []
-                    , hr [ css [ hrStyle ] ] []
-                    ]
-
-            else
-                text ""
+            div [ css [ partnerLogoContainer ] ]
+                [ img [ src logoUrl, css [ partnerLogoStyle ], alt (partnerName ++ " logo") ] []
+                , hr [ css [ hrStyle ] ] []
+                ]
 
         Nothing ->
-            text ""
+            div [] []
 
 
 

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -196,6 +196,7 @@ viewAddress maybeAddress =
         Nothing ->
             p [ css [ contactItemStyle ] ] [ text (t PartnerAddressEmptyText) ]
 
+
 partnerLogo : Maybe String -> String -> Html msg
 partnerLogo maybeLogoUrl partnerName =
     case maybeLogoUrl of
@@ -211,6 +212,7 @@ partnerLogo maybeLogoUrl partnerName =
 
         Nothing ->
             text ""
+
 
 
 ---------

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -1,7 +1,7 @@
 module Page.Partners.Partner_ exposing (Data, Model, Msg, page, view)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (googleMapSearchUrl, isValidUrl, t)
+import Copy.Text exposing (isValidUrl, t)
 import Css exposing (Style, auto, batch, calc, center, color, display, displayFlex, fontStyle, height, important, inlineBlock, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, paddingTop, pct, property, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -189,6 +189,8 @@ viewAddress maybeAddress =
                 , p [ css [ contactItemStyle ] ]
                     [ text addressFields.postalCode
                     ]
+                , p [ css [ contactItemStyle ] ]
+                    [ a [ href (t (GoogleMapSearchUrl addressFields.streetAddress)), css [ linkStyle ], target "_blank" ] [ text (t SeeOnGoogleMapText) ] ]
                 ]
 
         Nothing ->

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -196,19 +196,21 @@ viewAddress maybeAddress =
         Nothing ->
             p [ css [ contactItemStyle ] ] [ text (t PartnerAddressEmptyText) ]
 
-
 partnerLogo : Maybe String -> String -> Html msg
 partnerLogo maybeLogoUrl partnerName =
     case maybeLogoUrl of
         Just logoUrl ->
-            div [ css [ partnerLogoContainer ] ]
-                [ img [ src logoUrl, css [ partnerLogoStyle ], alt (partnerName ++ " logo") ] []
-                , hr [ css [ hrStyle ] ] []
-                ]
+            if isValidUrl logoUrl then
+                div [ css [ partnerLogoContainer ] ]
+                    [ img [ src logoUrl, css [ partnerLogoStyle ], alt (partnerName ++ " logo") ] []
+                    , hr [ css [ hrStyle ] ] []
+                    ]
+
+            else
+                text ""
 
         Nothing ->
-            div [] []
-
+            text ""
 
 
 ---------


### PR DESCRIPTION
Fixes #264

On show partner page, a link is rendered below the address that will take them to a google map page in a new tab
