### PR TITLE
Indicate whose events we're linking people to

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -66,6 +66,7 @@ type Key
       --- Event Page
     | EventTitle String
     | EventMetaDescription String String
+    | BackToPartnerEventsLinkText (Maybe String)
     | BackToEventsLinkText
       --- Partners Page
     | PartnersTitle

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -192,6 +192,9 @@ t key =
         EventMetaDescription eventName eventSummary ->
             eventName ++ " - " ++ eventSummary
 
+        BackToPartnerEventsLinkText partnerName ->
+            "All events by " ++ Maybe.withDefault "this partner" partnerName
+
         BackToEventsLinkText ->
             "All events"
 

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -193,7 +193,7 @@ t key =
             eventName ++ " - " ++ eventSummary
 
         BackToEventsLinkText ->
-            "Go to all events"
+            "All events"
 
         --- Partners Page
         PartnersTitle ->

--- a/src/Page/Events/Event_.elm
+++ b/src/Page/Events/Event_.elm
@@ -204,7 +204,7 @@ viewAddressSection event =
 viewButtons : Data.PlaceCal.Events.Event -> Html msg
 viewButtons event =
     section [ css [ buttonsStyle ] ]
-        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) ("All events by " ++ Maybe.withDefault "this partner" event.partner.name)
+        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) (t (BackToPartnerEventsLinkText event.partner.name))
         , Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl Events) (t BackToEventsLinkText)
         ]
 

--- a/src/Page/Events/Event_.elm
+++ b/src/Page/Events/Event_.elm
@@ -204,7 +204,7 @@ viewAddressSection event =
 viewButtons : Data.PlaceCal.Events.Event -> Html msg
 viewButtons event =
     section [ css [ buttonsStyle ] ]
-        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) "Partner's events"
+        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) ("All " ++ Maybe.withDefault "this partner" event.partner.name ++ "’s events")
         , Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl Events) (t BackToEventsLinkText)
         ]
 

--- a/src/Page/Events/Event_.elm
+++ b/src/Page/Events/Event_.elm
@@ -204,7 +204,7 @@ viewAddressSection event =
 viewButtons : Data.PlaceCal.Events.Event -> Html msg
 viewButtons event =
     section [ css [ buttonsStyle ] ]
-        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) ("All " ++ Maybe.withDefault "this partner" event.partner.name ++ "’s events")
+        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) ("All events by " ++ Maybe.withDefault "this partner" event.partner.name)
         , Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl Events) (t BackToEventsLinkText)
         ]
 


### PR DESCRIPTION
Relates to #240

## Description

<img width="684" alt="Screenshot 2022-09-28 at 17 02 17" src="https://user-images.githubusercontent.com/1027364/192814288-aafe5605-8868-4e7f-936a-0b11b53edd72.png">

We now include the partner's name in the button to find all partner events.

If we don't have a partner's name for some reason, we fall back to "this partner" instead.

I'm assuming that "{partner_name}'s" is always the correct grammar. I haven't thought about it very hard, though.