### PR TITLE
Jump to the events section from the event backlink

### DIFF
--- a/src/Page/Events/Event_.elm
+++ b/src/Page/Events/Event_.elm
@@ -204,7 +204,7 @@ viewAddressSection event =
 viewButtons : Data.PlaceCal.Events.Event -> Html msg
 viewButtons event =
     section [ css [ buttonsStyle ] ]
-        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) (t (BackToPartnerEventsLinkText event.partner.name))
+        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id) ++ "#events") (t (BackToPartnerEventsLinkText event.partner.name))
         , Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl Events) (t BackToEventsLinkText)
         ]
 

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -132,21 +132,21 @@ viewInfo { partner, events } =
         , hr [ css [ hrStyle ] ] []
         , section []
             [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
+            , if List.length events > 0 then
+                -- Might move away from sharing render, but for now hardcoding model
+                Page.Events.viewEventsList Nothing events
+
+              else
+                p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]
+            , case partner.maybeGeo of
+                Just geo ->
+                    div [ css [ mapContainerStyle ] ]
+                        [ p [] [ Theme.Global.mapImage { latitude = geo.latitude, longitude = geo.longitude } ]
+                        ]
+
+                Nothing ->
+                    div [ css [ mapContainerStyle ] ] [ text "" ]
             ]
-        , if List.length events > 0 then
-            -- Might move away from sharing render, but for now hardcoding model
-            Page.Events.viewEventsList Nothing events
-
-          else
-            p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]
-        , case partner.maybeGeo of
-            Just geo ->
-                div [ css [ mapContainerStyle ] ]
-                    [ p [] [ Theme.Global.mapImage { latitude = geo.latitude, longitude = geo.longitude } ]
-                    ]
-
-            Nothing ->
-                div [ css [ mapContainerStyle ] ] [ text "" ]
         ]
 
 

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -9,7 +9,7 @@ import DataSource exposing (DataSource)
 import Head
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, address, div, h3, hr, img, p, section, text)
-import Html.Styled.Attributes exposing (alt, css, href, src, target)
+import Html.Styled.Attributes exposing (alt, css, href, id, src, target)
 import Page exposing (Page, StaticPayload)
 import Page.Events
 import Pages.PageUrl exposing (PageUrl)
@@ -130,7 +130,7 @@ viewInfo { partner, events } =
                 ]
             ]
         , hr [ css [ hrStyle ] ] []
-        , section []
+        , section [ id "events" ]
             [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
             , if List.length events > 0 then
                 -- Might move away from sharing render, but for now hardcoding model


### PR DESCRIPTION
Fixes #240

## Description

Use an `id` to specify a deep link into the partner page from an event. This doesn't reliably actually jump to that section, presumably because it might not exist when the page first loads, though.

Opening as draft until it's resolved whether or not that's an issue in production or a feature of the development environment.
