### PR TITLE
Fix: only show events in the future

### DIFF
--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -189,7 +189,7 @@ t key =
             "Tomorrow"
 
         EventsFilterLabelAll ->
-            "All Events"
+            "All Future Events"
 
         --- Event Page
         EventTitle eventName ->

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -189,7 +189,7 @@ t key =
             "Tomorrow"
 
         EventsFilterLabelAll ->
-            "All Future Events"
+            "All future events"
 
         --- Event Page
         EventTitle eventName ->

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), emptyEvent, eventsAfterDate, eventsData, eventsFromDate, eventsFromPartnerId, next4Events)
+module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), afterDate, emptyEvent, eventsData, eventsFromDate, eventsFromPartnerId, next4Events)
 
 import Api
 import DataSource
@@ -91,8 +91,8 @@ eventsFromDate eventsList fromDate =
         eventsList
 
 
-eventsAfterDate : List Event -> Time.Posix -> List Event
-eventsAfterDate eventsList fromDate =
+afterDate : List Event -> Time.Posix -> List Event
+afterDate eventsList fromDate =
     List.filter
         (\event ->
             TransDate.isAfterDate event.startDatetime fromDate

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), emptyEvent, eventsData, eventsFromDate, eventsFromPartnerId, next4Events)
+module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), emptyEvent, eventsAfterDate, eventsData, eventsFromDate, eventsFromPartnerId, next4Events)
 
 import Api
 import DataSource
@@ -87,6 +87,15 @@ eventsFromDate eventsList fromDate =
     List.filter
         (\event ->
             TransDate.isSameDay event.startDatetime fromDate
+        )
+        eventsList
+
+
+eventsAfterDate : List Event -> Time.Posix -> List Event
+eventsAfterDate eventsList fromDate =
+    List.filter
+        (\event ->
+            TransDate.isAfterDate event.startDatetime fromDate
         )
         eventsList
 

--- a/src/Helpers/TransDate.elm
+++ b/src/Helpers/TransDate.elm
@@ -4,6 +4,7 @@ module Helpers.TransDate exposing
     , humanDayFromPosix
     , humanShortMonthFromPosix
     , humanTimeFromPosix
+    , isAfterDate
     , isSameDay
     , isoDateStringDecoder
     )
@@ -53,6 +54,11 @@ isSameDay aDay anotherDay =
         == Time.toMonth Time.utc anotherDay
         && Time.toYear Time.utc aDay
         == Time.toYear Time.utc anotherDay
+
+
+isAfterDate : Time.Posix -> Time.Posix -> Bool
+isAfterDate aDay anotherDay =
+    Time.posixToMillis aDay > Time.posixToMillis anotherDay
 
 
 

--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -90,7 +90,7 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
         ClickedAllEvents ->
             ( { localModel
                 | filterByDay = Nothing
-                , visibleEvents = static.data
+                , visibleEvents = Data.PlaceCal.Events.eventsAfterDate static.data localModel.nowTime
               }
             , Cmd.none
             )

--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -90,7 +90,7 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
         ClickedAllEvents ->
             ( { localModel
                 | filterByDay = Nothing
-                , visibleEvents = Data.PlaceCal.Events.eventsAfterDate static.data localModel.nowTime
+                , visibleEvents = Data.PlaceCal.Events.afterDate static.data localModel.nowTime
               }
             , Cmd.none
             )


### PR DESCRIPTION
Fixes #282

On Events page, when 'all events' is selected, only show events after the current day.
