### PR TITLE
Feat/206 add pagination to partner event page

### DIFF
--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -1,10 +1,10 @@
 module Page.Events exposing (Data, Filter(..), Model, Msg, addPartnerNamesToEvents, page, view, viewFutureEventsList)
 
-import Browser.Dom exposing (Error, Viewport, getViewport, getViewportOf, setViewportOf)
+import Browser.Dom exposing (Viewport)
 import Browser.Navigation
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
-import Css exposing (Style, active, alignItems, auto, backgroundColor, batch, block, borderBottomColor, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, calc, center, color, column, cursor, deg, display, displayFlex, em, firstChild, fitContent, flexDirection, flexGrow, flexWrap, focus, fontSize, fontStyle, fontWeight, height, hover, important, int, italic, justifyContent, lastChild, letterSpacing, lineHeight, listStyleType, margin, margin2, margin4, marginBlockEnd, marginBlockStart, marginBottom, marginLeft, marginRight, marginTop, maxWidth, minus, noWrap, none, overflowX, padding2, padding4, paddingBottom, paddingLeft, paddingRight, pct, plus, pointer, position, property, pseudoElement, px, relative, rem, rotate, row, rowReverse, scroll, solid, spaceBetween, textAlign, textDecoration, textTransform, transform, uppercase, width, wrap)
+import Css exposing (Style, active, alignItems, auto, backgroundColor, batch, block, borderBottomColor, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, calc, center, color, column, cursor, deg, display, displayFlex, em, firstChild, fitContent, flexDirection, flexGrow, flexWrap, focus, fontSize, fontStyle, fontWeight, height, hover, important, int, italic, justifyContent, lastChild, letterSpacing, lineHeight, listStyleType, margin, margin2, margin4, marginBlockEnd, marginBlockStart, marginBottom, marginRight, marginTop, maxWidth, minus, noWrap, none, overflowX, padding2, padding4, paddingBottom, paddingLeft, paddingRight, pct, pointer, position, property, pseudoElement, px, relative, rem, rotate, row, rowReverse, scroll, solid, spaceBetween, textAlign, textDecoration, textTransform, transform, uppercase, width, wrap)
 import Css.Global exposing (descendants, typeSelector)
 import Css.Transitions exposing (transition)
 import Data.PlaceCal.Events
@@ -15,15 +15,15 @@ import Helpers.TransDate as TransDate
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, button, div, h4, img, li, p, section, span, text, time, ul)
 import Html.Styled.Attributes exposing (css, href, id, src)
-import Html.Styled.Events exposing (onClick)
+import Html.Styled.Events
 import Page exposing (PageWithState, StaticPayload)
 import Pages.PageUrl exposing (PageUrl)
 import Path exposing (Path)
-import Process
 import Shared
-import Task exposing (Task)
+import Task
 import Theme.Global exposing (backgroundColorTransition, borderTransition, colorTransition, darkBlue, darkPurple, introTextLargeStyle, pink, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.PageTemplate as PageTemplate
+import Theme.Paginator as Paginator
 import Time
 import View exposing (View)
 
@@ -123,7 +123,7 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
         ScrollRight ->
             ( localModel
             , Task.attempt (\_ -> NoOp)
-                (scrollPagination
+                (Paginator.scrollPagination
                     (if localModel.viewportWidth < Theme.Global.maxMobile then
                         buttonWidthMobile + (buttonMarginMobile * 2)
 
@@ -139,7 +139,7 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
         ScrollLeft ->
             ( localModel
             , Task.attempt (\_ -> NoOp)
-                (scrollPagination
+                (Paginator.scrollPagination
                     (if localModel.viewportWidth < Theme.Global.maxMobile then
                         -(buttonWidthMobile + (buttonMarginMobile * 2))
 
@@ -372,39 +372,6 @@ addDays days now =
     (days * 24 * 60 * 60 * 1000)
         + Time.posixToMillis now
         |> Time.millisToPosix
-
-
-scrollPagination : Float -> Task Error ()
-scrollPagination scrollXFloat =
-    getViewportOf "scrollable"
-        |> Task.andThen (\info -> scrollX scrollXFloat info.viewport.x)
-
-
-posOrNeg : Float -> Float
-posOrNeg numToTest =
-    toFloat
-        (if numToTest > 0 then
-            1
-
-         else
-            -1
-        )
-
-
-scrollX : Float -> Float -> Task Error ()
-scrollX scrollRemaining viewportXPosition =
-    let
-        pixelsLeftToMove =
-            round (posOrNeg scrollRemaining * scrollRemaining)
-    in
-    if pixelsLeftToMove < 6 then
-        getViewportOf "scrollable"
-            |> Task.andThen (\_ -> setViewportOf "scrollable" (viewportXPosition + scrollRemaining) 0)
-
-    else
-        getViewportOf "scrollable"
-            |> Task.andThen (\_ -> setViewportOf "scrollable" (viewportXPosition + posOrNeg scrollRemaining * 5) 0)
-            |> Task.andThen (\_ -> scrollX (scrollRemaining - posOrNeg scrollRemaining * 5) (viewportXPosition + posOrNeg scrollRemaining * 5))
 
 
 

--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -1,4 +1,4 @@
-module Page.Events exposing (Data, Model, Msg, addPartnerNamesToEvents, page, view, viewFutureEventsList)
+module Page.Events exposing (Data, Model, Msg, addPartnerNamesToEvents, page, view, viewEvents, viewFutureEventsList)
 
 import Browser.Dom
 import Browser.Navigation
@@ -216,10 +216,6 @@ viewEvents localModel =
         [ Paginator.viewPagination localModel
         , viewEventsList localModel.filterBy localModel.visibleEvents
         ]
-
-
-
--- We might want to move this into theme since it is also used by Partner page
 
 
 viewFutureEventsList : List Data.PlaceCal.Events.Event -> Html msg

--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -1,4 +1,4 @@
-module Page.Events exposing (Data, Model, Msg, addPartnerNamesToEvents, page, view, viewEvents, viewFutureEventsList)
+module Page.Events exposing (Data, Model, Msg, addPartnerNamesToEvents, page, view, viewEvents, viewEventsList)
 
 import Browser.Dom
 import Browser.Navigation
@@ -49,7 +49,7 @@ init :
     -> StaticPayload Data RouteParams
     -> ( Model, Cmd Msg )
 init maybeUrl sharedModel static =
-    ( { filterBy = Paginator.Future
+    ( { filterBy = Paginator.None
       , visibleEvents = static.data
       , nowTime = Time.millisToPosix 0
       , viewportWidth = 320
@@ -214,21 +214,21 @@ viewEvents : Model -> Html Msg
 viewEvents localModel =
     section [ css [ eventsContainerStyle ] ]
         [ Paginator.viewPagination localModel
-        , viewEventsList localModel.filterBy localModel.visibleEvents
+        , viewFilteredEventsList localModel.filterBy localModel.visibleEvents
         ]
 
 
-viewFutureEventsList : List Data.PlaceCal.Events.Event -> Html msg
-viewFutureEventsList events =
-    viewEventsList Paginator.Future events
+viewEventsList : List Data.PlaceCal.Events.Event -> Html msg
+viewEventsList events =
+    viewFilteredEventsList Paginator.Unknown events
 
 
-viewEventsList : Paginator.Filter -> List Data.PlaceCal.Events.Event -> Html msg
-viewEventsList filter events =
+viewFilteredEventsList : Paginator.Filter -> List Data.PlaceCal.Events.Event -> Html msg
+viewFilteredEventsList filter filteredEvents =
     div []
-        [ if List.length events > 0 then
+        [ if List.length filteredEvents > 0 then
             ul [ css [ eventListStyle ] ]
-                (List.map (\event -> viewEvent event) events)
+                (List.map (\event -> viewEvent event) filteredEvents)
 
           else
             p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ]

--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -109,33 +109,13 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
         ScrollRight ->
             ( localModel
             , Task.attempt (\_ -> NoOp)
-                (Paginator.scrollPagination
-                    (if localModel.viewportWidth < Theme.Global.maxMobile then
-                        buttonWidthMobile + (buttonMarginMobile * 2)
-
-                     else if localModel.viewportWidth < Theme.Global.maxTabletPortrait then
-                        buttonWidthTablet + (buttonMarginTablet * 2)
-
-                     else
-                        buttonWidthFullWidth + (buttonMarginFullWidth * 2)
-                    )
-                )
+                (Paginator.scrollPagination Paginator.Right localModel.viewportWidth)
             )
 
         ScrollLeft ->
             ( localModel
             , Task.attempt (\_ -> NoOp)
-                (Paginator.scrollPagination
-                    (if localModel.viewportWidth < Theme.Global.maxMobile then
-                        -(buttonWidthMobile + (buttonMarginMobile * 2))
-
-                     else if localModel.viewportWidth < Theme.Global.maxTabletPortrait then
-                        -(buttonWidthTablet + (buttonMarginTablet * 2))
-
-                     else
-                        -(buttonWidthFullWidth + (buttonMarginFullWidth * 2))
-                    )
-                )
+                (Paginator.scrollPagination Paginator.Left localModel.viewportWidth)
             )
 
         GotViewport viewport ->
@@ -143,36 +123,6 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
 
         NoOp ->
             ( localModel, Cmd.none )
-
-
-buttonWidthMobile : Float
-buttonWidthMobile =
-    100
-
-
-buttonMarginMobile : Float
-buttonMarginMobile =
-    4
-
-
-buttonWidthTablet : Float
-buttonWidthTablet =
-    110
-
-
-buttonMarginTablet : Float
-buttonMarginTablet =
-    6
-
-
-buttonWidthFullWidth : Float
-buttonWidthFullWidth =
-    130
-
-
-buttonMarginFullWidth : Float
-buttonMarginFullWidth =
-    8
 
 
 subscriptions :

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -129,7 +129,7 @@ viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Html msg
 viewFeatured fromTime eventList =
     section [ css [ sectionStyle, darkBlueBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ Theme.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
-        , Page.Events.viewFutureEventsList (Data.PlaceCal.Events.next4Events eventList fromTime)
+        , Page.Events.viewEventsList (Data.PlaceCal.Events.next4Events eventList fromTime)
         , p [ css [ buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (TransRoutes.toAbsoluteUrl Events)

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -48,7 +48,7 @@ init :
     -> StaticPayload Data RouteParams
     -> ( Model, Cmd Msg )
 init maybeUrl sharedModel static =
-    ( { filterBy = Paginator.Future
+    ( { filterBy = Paginator.None
       , visibleEvents = static.data.events
       , nowTime = Time.millisToPosix 0
       , viewportWidth = 320
@@ -246,7 +246,7 @@ viewInfo localModel { partner, events } =
                 Page.Events.viewEvents localModel
 
             else
-                Page.Events.viewFutureEventsList events
+                Page.Events.viewEventsList events
 
           else
             p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -82,7 +82,7 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
         ClickedAllPastEvents ->
             ( { localModel
                 | filterBy = Paginator.Past
-                , visibleEvents = static.data.events
+                , visibleEvents = List.reverse (Data.PlaceCal.Events.onOrBeforeDate static.data.events localModel.nowTime)
               }
             , Cmd.none
             )
@@ -90,7 +90,7 @@ update pageUrl maybeNavigationKey sharedModel static msg localModel =
         ClickedAllFutureEvents ->
             ( { localModel
                 | filterBy = Paginator.Future
-                , visibleEvents = static.data.events
+                , visibleEvents = Data.PlaceCal.Events.afterDate static.data.events localModel.nowTime
               }
             , Cmd.none
             )

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -242,8 +242,11 @@ viewInfo localModel { partner, events } =
             [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
             ]
         , if List.length events > 0 then
-            -- Might move away from sharing render, but for now hardcoding model
-            Page.Events.viewEvents localModel
+            if List.length events > 20 then
+                Page.Events.viewEvents localModel
+
+            else
+                Page.Events.viewFutureEventsList events
 
           else
             p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -1,8 +1,10 @@
 module Page.Partners.Partner_ exposing (Data, Model, Msg, page, view)
 
+import Browser.Dom
+import Browser.Navigation
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (isValidUrl, t)
-import Css exposing (Style, auto, batch, calc, center, color, display, displayFlex, fontStyle, height, important, inlineBlock, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, paddingTop, pct, property, px, rem, textAlign, width)
+import Css exposing (Style, auto, batch, calc, center, color, display, displayFlex, fontStyle, important, inlineBlock, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, paddingTop, pct, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
 import DataSource exposing (DataSource)
@@ -10,36 +12,141 @@ import Head
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, address, div, h3, hr, img, p, section, text)
 import Html.Styled.Attributes exposing (alt, css, href, src, target)
-import Page exposing (Page, StaticPayload)
+import Page exposing (PageWithState, StaticPayload)
 import Page.Events
 import Pages.PageUrl exposing (PageUrl)
+import Path exposing (Path)
 import Shared
+import Task
 import Theme.Global exposing (hrStyle, introTextLargeStyle, linkStyle, normalFirstParagraphStyle, pink, smallInlineTitleStyle, viewBackButton, white, withMediaMediumDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.PageTemplate as PageTemplate
+import Theme.Paginator as Paginator exposing (Msg(..))
 import Theme.TransMarkdown
+import Time
 import View exposing (View)
 
 
 type alias Model =
-    ()
+    { filterBy : Paginator.Filter
+    , visibleEvents : List Data.PlaceCal.Events.Event
+    , nowTime : Time.Posix
+    , viewportWidth : Float
+    }
 
 
 type alias Msg =
-    Never
+    Paginator.Msg
 
 
 type alias RouteParams =
     { partner : String }
 
 
-page : Page RouteParams Data
+init :
+    Maybe PageUrl
+    -> Shared.Model
+    -> StaticPayload Data RouteParams
+    -> ( Model, Cmd Msg )
+init maybeUrl sharedModel static =
+    ( { filterBy = Paginator.Future
+      , visibleEvents = static.data.events
+      , nowTime = Time.millisToPosix 0
+      , viewportWidth = 320
+      }
+    , Cmd.batch
+        [ Task.perform GetTime Time.now
+        , Task.perform GotViewport Browser.Dom.getViewport
+        ]
+    )
+
+
+update :
+    PageUrl
+    -> Maybe Browser.Navigation.Key
+    -> Shared.Model
+    -> StaticPayload Data RouteParams
+    -> Msg
+    -> Model
+    -> ( Model, Cmd Msg )
+update pageUrl maybeNavigationKey sharedModel static msg localModel =
+    case msg of
+        ClickedDay posix ->
+            ( { localModel
+                | filterBy = Paginator.Day posix
+                , visibleEvents =
+                    Data.PlaceCal.Events.eventsFromDate static.data.events posix
+              }
+            , Cmd.none
+            )
+
+        ClickedAllPastEvents ->
+            ( { localModel
+                | filterBy = Paginator.Past
+                , visibleEvents = static.data.events
+              }
+            , Cmd.none
+            )
+
+        ClickedAllFutureEvents ->
+            ( { localModel
+                | filterBy = Paginator.Future
+                , visibleEvents = static.data.events
+              }
+            , Cmd.none
+            )
+
+        GetTime newTime ->
+            ( { localModel
+                | filterBy = Paginator.Day newTime
+                , nowTime = newTime
+                , visibleEvents =
+                    Data.PlaceCal.Events.eventsFromDate static.data.events newTime
+              }
+            , Cmd.none
+            )
+
+        ScrollRight ->
+            ( localModel
+            , Task.attempt (\_ -> NoOp)
+                (Paginator.scrollPagination Paginator.Right localModel.viewportWidth)
+            )
+
+        ScrollLeft ->
+            ( localModel
+            , Task.attempt (\_ -> NoOp)
+                (Paginator.scrollPagination Paginator.Left localModel.viewportWidth)
+            )
+
+        GotViewport viewport ->
+            ( { localModel | viewportWidth = Maybe.withDefault localModel.viewportWidth (Just viewport.scene.width) }, Cmd.none )
+
+        NoOp ->
+            ( localModel, Cmd.none )
+
+
+subscriptions :
+    Maybe PageUrl
+    -> RouteParams
+    -> Path
+    -> Model
+    -> Sub Msg
+subscriptions _ _ _ _ =
+    Sub.none
+
+
+page : PageWithState RouteParams Data Model Msg
 page =
     Page.prerender
         { head = head
         , routes = routes
         , data = data
         }
-        |> Page.buildNoState { view = view }
+        |> Page.buildWithLocalState
+            { init = init
+            , view = view
+            , update = update
+            , subscriptions = subscriptions
+            }
 
 
 routes : DataSource (List RouteParams)
@@ -94,9 +201,10 @@ type alias Data =
 view :
     Maybe PageUrl
     -> Shared.Model
+    -> Model
     -> StaticPayload Data RouteParams
     -> View Msg
-view maybeUrl sharedModel static =
+view maybeUrl sharedModel localModel static =
     { title = t (PageMetaTitle static.data.partner.name)
     , body =
         [ PageTemplate.view
@@ -106,15 +214,15 @@ view maybeUrl sharedModel static =
             , smallText = Nothing
             , innerContent =
                 Just
-                    (viewInfo static.data)
+                    (viewInfo localModel static.data)
             , outerContent = Just (viewBackButton (TransRoutes.toAbsoluteUrl Partners) (t BackToPartnersLinkText))
             }
         ]
     }
 
 
-viewInfo : Data -> Html msg
-viewInfo { partner, events } =
+viewInfo : Model -> Data -> Html Msg
+viewInfo localModel { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
         [ partnerLogo partner.maybeLogo partner.name
         , div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (t (PartnerDescriptionText partner.description partner.name)))
@@ -135,7 +243,7 @@ viewInfo { partner, events } =
             ]
         , if List.length events > 0 then
             -- Might move away from sharing render, but for now hardcoding model
-            Page.Events.viewFutureEventsList events
+            Page.Events.viewEvents localModel
 
           else
             p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -1,7 +1,125 @@
-module Theme.Paginator exposing (scrollPagination)
+module Theme.Paginator exposing (Filter(..), Msg(..), scrollPagination, viewPagination)
 
-import Browser.Dom exposing (Error, getViewportOf, setViewportOf)
+import Browser.Dom exposing (Error, Viewport, getViewportOf, setViewportOf)
+import Copy.Keys exposing (Key(..))
+import Copy.Text exposing (t)
+import Css exposing (Style, active, auto, backgroundColor, batch, borderBox, borderColor, borderRadius, borderStyle, borderWidth, boxSizing, center, color, cursor, deg, display, displayFlex, fitContent, flexWrap, focus, fontSize, fontWeight, height, hover, important, int, justifyContent, listStyleType, margin, margin2, margin4, maxWidth, noWrap, none, overflowX, padding2, padding4, paddingLeft, paddingRight, pct, pointer, position, property, pseudoElement, px, relative, rem, rotate, scroll, solid, textAlign, transform, width, wrap)
+import Css.Global exposing (descendants, typeSelector)
+import Css.Transitions exposing (transition)
+import Helpers.TransDate as TransDate
+import Html.Styled exposing (Html, button, div, img, li, text, ul)
+import Html.Styled.Attributes exposing (css, id, src)
+import Html.Styled.Events
 import Task exposing (Task)
+import Theme.Global exposing (backgroundColorTransition, borderTransition, colorTransition, darkBlue, darkPurple, pink, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Time
+
+
+type Filter
+    = Day Time.Posix
+    | Past
+    | Future
+
+
+type Msg
+    = ClickedDay Time.Posix
+    | ClickedAllPastEvents
+    | ClickedAllFutureEvents
+    | GetTime Time.Posix
+    | GotViewport Viewport
+    | ScrollRight
+    | ScrollLeft
+    | NoOp
+
+
+viewPagination :
+    { localModel
+        | filterBy : Filter
+        , nowTime : Time.Posix
+    }
+    -> Html Msg
+viewPagination localModel =
+    div [ css [ paginationWrapper ] ]
+        [ div [ css [ paginationContainer ] ]
+            [ button [ css [ paginationArrowButtonStyle ], Html.Styled.Events.onClick ScrollLeft ] [ img [ src "/images/icons/leftarrow.svg", css [ paginationArrowStyle ] ] [] ]
+            , div [ css [ paginationScrollableBoxStyle ], id "scrollable" ]
+                [ ul [ css [ paginationButtonListStyle ] ]
+                    (List.map
+                        (\( label, buttonTime ) ->
+                            li [ css [ paginationButtonListItemStyle ] ]
+                                [ button
+                                    [ css
+                                        [ case localModel.filterBy of
+                                            Day day ->
+                                                if TransDate.isSameDay buttonTime day then
+                                                    paginationButtonListItemButtonActiveStyle
+
+                                                else
+                                                    paginationButtonListItemButtonStyle
+
+                                            _ ->
+                                                paginationButtonListItemButtonStyle
+                                        ]
+                                    , Html.Styled.Events.onClick (ClickedDay buttonTime)
+                                    ]
+                                    [ text label ]
+                                ]
+                        )
+                        (todayTomorrowNext5DaysPosix localModel.nowTime)
+                    )
+                ]
+            , button [ css [ paginationArrowButtonRightStyle ], id "arrow-right", Html.Styled.Events.onClick ScrollRight ] [ img [ src "/images/icons/rightarrow.svg", css [ paginationRightArrowStyle ] ] [] ]
+            ]
+        , div [ css [ paginationContainer ] ]
+            [ ul [ css [ allEventsButtonListStyle ] ]
+                [ li [ css [ allEventsButtonListItemStyle ] ]
+                    [ button
+                        [ css
+                            (if localModel.filterBy == Past then
+                                [ important (width (px 200)), paginationButtonListItemButtonActiveStyle ]
+
+                             else
+                                [ important (width (px 200)), paginationButtonListItemButtonStyle ]
+                            )
+                        , Html.Styled.Events.onClick ClickedAllPastEvents
+                        ]
+                        [ text (t EventsFilterLabelAllPast) ]
+                    ]
+                , li [ css [ allEventsButtonListItemStyle ] ]
+                    [ button
+                        [ css
+                            (if localModel.filterBy == Future then
+                                [ important (width (px 200)), paginationButtonListItemButtonActiveStyle ]
+
+                             else
+                                [ important (width (px 200)), paginationButtonListItemButtonStyle ]
+                            )
+                        , Html.Styled.Events.onClick ClickedAllFutureEvents
+                        ]
+                        [ text (t EventsFilterLabelAllFuture) ]
+                    ]
+                ]
+            ]
+        ]
+
+
+todayTomorrowNext5DaysPosix : Time.Posix -> List ( String, Time.Posix )
+todayTomorrowNext5DaysPosix now =
+    [ ( t EventsFilterLabelToday, now )
+    , ( t EventsFilterLabelTomorrow, addDays 1 now )
+    ]
+        ++ List.map
+            (\days ->
+                ( TransDate.humanDayDateMonthFromPosix (addDays days now), addDays days now )
+            )
+            [ 2, 3, 4, 5, 6 ]
+
+
+addDays : Int -> Time.Posix -> Time.Posix
+addDays days now =
+    (days * 24 * 60 * 60 * 1000)
+        + Time.posixToMillis now
+        |> Time.millisToPosix
 
 
 scrollPagination : Float -> Task Error ()
@@ -35,3 +153,236 @@ posOrNeg numToTest =
          else
             -1
         )
+
+
+
+-- Styles
+
+
+numberOfButtons : Float
+numberOfButtons =
+    7
+
+
+buttonWidthMobile : Float
+buttonWidthMobile =
+    100
+
+
+buttonMarginMobile : Float
+buttonMarginMobile =
+    4
+
+
+buttonWidthTablet : Float
+buttonWidthTablet =
+    110
+
+
+buttonMarginTablet : Float
+buttonMarginTablet =
+    6
+
+
+buttonWidthFullWidth : Float
+buttonWidthFullWidth =
+    130
+
+
+buttonMarginFullWidth : Float
+buttonMarginFullWidth =
+    8
+
+
+paginationWrapper : Style
+paginationWrapper =
+    batch
+        [ margin2 (rem 0) (rem -0.5)
+        , withMediaSmallDesktopUp [ margin4 (rem 2) (rem -1) (rem 3) (rem -1) ]
+        , withMediaTabletLandscapeUp [ margin2 (rem 2) (rem -1) ]
+        ]
+
+
+paginationContainer : Style
+paginationContainer =
+    batch
+        [ displayFlex
+        , maxWidth fitContent
+        , margin4 (rem 0) auto (rem 0.5) auto
+        , withMediaSmallDesktopUp [ margin2 (rem 0) auto ]
+        , withMediaTabletLandscapeUp [ margin2 (rem 0) auto ]
+        ]
+
+
+paginationScrollableBoxStyle : Style
+paginationScrollableBoxStyle =
+    batch
+        [ width (px (buttonWidthMobile * 2 + buttonMarginMobile * 4))
+        , position relative
+        , overflowX scroll
+        , pseudoElement "-webkit-scrollbar" [ display none ]
+        , property "-ms-overflow-style" "none"
+        , property "scrollbar-width" "none"
+        , property "scroll-behaviour" "smooth"
+        , withMediaSmallDesktopUp [ width (pct 100) ]
+        , withMediaTabletLandscapeUp [ width (px (buttonWidthFullWidth * 5 + buttonMarginFullWidth * 10)) ]
+        , withMediaTabletPortraitUp [ width (px (buttonWidthTablet * 4 + buttonMarginTablet * 8)) ]
+        ]
+
+
+paginationButtonStyle : Style
+paginationButtonStyle =
+    batch
+        [ borderStyle solid
+        , borderColor pink
+        , borderWidth (px 2)
+        , color pink
+        , borderRadius (rem 0.3)
+        , textAlign center
+        , cursor pointer
+        , hover
+            [ backgroundColor darkPurple
+            , color white
+            , borderColor white
+            , descendants [ typeSelector "img" [ property "filter" "invert(1)" ] ]
+            ]
+        , focus
+            [ backgroundColor white
+            , color darkBlue
+            , borderColor white
+            , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
+            ]
+        , active
+            [ backgroundColor white
+            , color darkBlue
+            , borderColor white
+            , descendants [ typeSelector "img" [ property "filter" "invert(0)" ] ]
+            ]
+        , transition [ colorTransition, borderTransition, backgroundColorTransition ]
+        ]
+
+
+paginationArrowButtonStyle : Style
+paginationArrowButtonStyle =
+    batch
+        [ paginationButtonStyle
+        , backgroundColor pink
+        , margin4 (rem 0.25) (rem 0.25) (rem 0.25) (rem 0)
+        , paddingRight (rem 0.5)
+        , withMediaSmallDesktopUp [ display none ]
+        , withMediaTabletLandscapeUp
+            [ padding2 (rem 0) (rem 0.5), margin2 (rem 0.25) (rem 0.75) ]
+        , withMediaTabletPortraitUp
+            [ margin4 (rem 0.25) (rem 0.5) (rem 0.25) (rem 0) ]
+        ]
+
+
+paginationArrowButtonRightStyle : Style
+paginationArrowButtonRightStyle =
+    batch
+        [ paginationButtonStyle
+        , backgroundColor pink
+        , margin4 (rem 0.25) (rem 0) (rem 0.25) (rem 0.25)
+        , paddingLeft (rem 0.5)
+        , withMediaSmallDesktopUp [ display none ]
+        , withMediaTabletLandscapeUp
+            [ padding2 (rem 0) (rem 0.5), margin2 (rem 0.25) (rem 0.75) ]
+        , withMediaTabletPortraitUp
+            [ margin4 (rem 0.25) (rem 0) (rem 0.25) (rem 0.5) ]
+        ]
+
+
+paginationArrowStyle : Style
+paginationArrowStyle =
+    batch
+        [ width (px 13)
+        , height (px 11)
+        , withMediaTabletPortraitUp [ width (px 18), height (px 15) ]
+        ]
+
+
+paginationRightArrowStyle : Style
+paginationRightArrowStyle =
+    batch
+        [ paginationArrowStyle
+        , transform (rotate (deg 180))
+        ]
+
+
+buttonListStyle : Style
+buttonListStyle =
+    batch
+        [ displayFlex
+        , justifyContent center
+        , boxSizing borderBox
+        , position relative
+        , width (px (buttonWidthMobile * numberOfButtons + buttonMarginMobile * (numberOfButtons * 2)))
+        , withMediaTabletLandscapeUp
+            [ width (px (buttonWidthFullWidth * numberOfButtons + buttonMarginFullWidth * (numberOfButtons * 2))) ]
+        , withMediaTabletPortraitUp
+            [ width (px (buttonWidthTablet * numberOfButtons + buttonMarginTablet * (numberOfButtons * 2))) ]
+        ]
+
+
+paginationButtonListStyle : Style
+paginationButtonListStyle =
+    batch
+        [ buttonListStyle
+        , flexWrap noWrap
+        ]
+
+
+allEventsButtonListStyle : Style
+allEventsButtonListStyle =
+    batch
+        [ buttonListStyle
+        , flexWrap wrap
+        ]
+
+
+paginationButtonListItemStyle : Style
+paginationButtonListItemStyle =
+    batch
+        [ margin2 (rem 0.25) (px buttonMarginMobile)
+        , listStyleType none
+        , withMediaTabletLandscapeUp [ margin2 (rem 0.25) (rem 0.5) ]
+        , withMediaTabletPortraitUp [ margin2 (rem 0.25) (rem 0.375) ]
+        ]
+
+
+allEventsButtonListItemStyle : Style
+allEventsButtonListItemStyle =
+    batch
+        [ listStyleType none
+        , textAlign center
+        , margin (rem 0.5)
+        ]
+
+
+paginationButtonListItemButtonStyle : Style
+paginationButtonListItemButtonStyle =
+    batch
+        [ paginationButtonStyle
+        , fontSize (rem 0.875)
+        , fontWeight (int 600)
+        , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
+        , width (px buttonWidthMobile)
+        , backgroundColor darkBlue
+        , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
+        , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
+        ]
+
+
+paginationButtonListItemButtonActiveStyle : Style
+paginationButtonListItemButtonActiveStyle =
+    batch
+        [ paginationButtonStyle
+        , fontSize (rem 0.875)
+        , fontWeight (int 600)
+        , padding4 (rem 0.2) (rem 0.2) (rem 0.3) (rem 0.2)
+        , width (px buttonWidthMobile)
+        , backgroundColor pink
+        , color darkBlue
+        , withMediaTabletLandscapeUp [ width (px buttonWidthFullWidth), fontSize (rem 1.2) ]
+        , withMediaTabletPortraitUp [ width (px buttonWidthTablet), fontSize (rem 1) ]
+        ]

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -19,6 +19,8 @@ type Filter
     = Day Time.Posix
     | Past
     | Future
+    | None
+    | Unknown
 
 
 type Msg

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -1,4 +1,4 @@
-module Theme.Paginator exposing (Filter(..), Msg(..), scrollPagination, viewPagination)
+module Theme.Paginator exposing (Filter(..), Msg(..), ScrollDirection(..), scrollPagination, viewPagination)
 
 import Browser.Dom exposing (Error, Viewport, getViewportOf, setViewportOf)
 import Copy.Keys exposing (Key(..))
@@ -30,6 +30,11 @@ type Msg
     | ScrollRight
     | ScrollLeft
     | NoOp
+
+
+type ScrollDirection
+    = Right
+    | Left
 
 
 viewPagination :
@@ -122,10 +127,29 @@ addDays days now =
         |> Time.millisToPosix
 
 
-scrollPagination : Float -> Task Error ()
-scrollPagination scrollXFloat =
+scrollPagination : ScrollDirection -> Float -> Task Error ()
+scrollPagination direction viewportWidth =
+    let
+        scrollXAmount =
+            if viewportWidth < Theme.Global.maxMobile then
+                buttonWidthMobile + (buttonMarginMobile * 2)
+
+            else if viewportWidth < Theme.Global.maxTabletPortrait then
+                buttonWidthTablet + (buttonMarginTablet * 2)
+
+            else
+                buttonWidthFullWidth + (buttonMarginFullWidth * 2)
+
+        scrollXValue =
+            case direction of
+                Right ->
+                    scrollXAmount
+
+                Left ->
+                    -scrollXAmount
+    in
     getViewportOf "scrollable"
-        |> Task.andThen (\info -> scrollX scrollXFloat info.viewport.x)
+        |> Task.andThen (\info -> scrollX scrollXValue info.viewport.x)
 
 
 scrollX : Float -> Float -> Task Error ()

--- a/src/Theme/Paginator.elm
+++ b/src/Theme/Paginator.elm
@@ -1,0 +1,37 @@
+module Theme.Paginator exposing (scrollPagination)
+
+import Browser.Dom exposing (Error, getViewportOf, setViewportOf)
+import Task exposing (Task)
+
+
+scrollPagination : Float -> Task Error ()
+scrollPagination scrollXFloat =
+    getViewportOf "scrollable"
+        |> Task.andThen (\info -> scrollX scrollXFloat info.viewport.x)
+
+
+scrollX : Float -> Float -> Task Error ()
+scrollX scrollRemaining viewportXPosition =
+    let
+        pixelsLeftToMove =
+            round (posOrNeg scrollRemaining * scrollRemaining)
+    in
+    if pixelsLeftToMove < 6 then
+        getViewportOf "scrollable"
+            |> Task.andThen (\_ -> setViewportOf "scrollable" (viewportXPosition + scrollRemaining) 0)
+
+    else
+        getViewportOf "scrollable"
+            |> Task.andThen (\_ -> setViewportOf "scrollable" (viewportXPosition + posOrNeg scrollRemaining * 5) 0)
+            |> Task.andThen (\_ -> scrollX (scrollRemaining - posOrNeg scrollRemaining * 5) (viewportXPosition + posOrNeg scrollRemaining * 5))
+
+
+posOrNeg : Float -> Float
+posOrNeg numToTest =
+    toFloat
+        (if numToTest > 0 then
+            1
+
+         else
+            -1
+        )

--- a/tests/Page/EventsTests.elm
+++ b/tests/Page/EventsTests.elm
@@ -5,12 +5,13 @@ import Copy.Text exposing (t)
 import Data.TestFixtures as Fixtures exposing (sharedModelInit)
 import Expect
 import Html
-import Page.Events exposing (Filter(..), view)
+import Page.Events exposing (view)
 import Path
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 import TestUtils exposing (queryFromStyledList)
+import Theme.Paginator as Paginator
 import Time
 
 
@@ -23,7 +24,7 @@ viewParamsWithEvents =
 
 
 eventsModel =
-    { filterBy = Future
+    { filterBy = Paginator.None
     , visibleEvents = Fixtures.events
     , nowTime = Time.millisToPosix 0
     , viewportWidth = 1920
@@ -31,7 +32,7 @@ eventsModel =
 
 
 eventsModelNoEvents =
-    { filterBy = Future
+    { filterBy = Paginator.None
     , visibleEvents = []
     , nowTime = Time.millisToPosix 0
     , viewportWidth = 1920

--- a/tests/Page/PartnerTests.elm
+++ b/tests/Page/PartnerTests.elm
@@ -12,6 +12,7 @@ import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
 import TestUtils exposing (queryFromStyledList)
+import Theme.Paginator as Paginator
 import Time
 
 
@@ -90,9 +91,17 @@ viewParamsWithoutEvents =
     }
 
 
-viewBodyHtml viewParams =
+eventsModel =
+    { filterBy = Paginator.None
+    , visibleEvents = Fixtures.events
+    , nowTime = Time.millisToPosix 0
+    , viewportWidth = 1920
+    }
+
+
+viewBodyHtml localModel viewParams =
     queryFromStyledList
-        (view Nothing Fixtures.sharedModelInit viewParams).body
+        (view Nothing Fixtures.sharedModelInit localModel viewParams).body
 
 
 suite : Test
@@ -100,25 +109,25 @@ suite =
     describe "Partner page body"
         [ test "Has expected h2 heading" <|
             \_ ->
-                viewBodyHtml viewParamsWithPartner
+                viewBodyHtml eventsModel viewParamsWithPartner
                     |> Query.findAll [ Selector.tag "h2" ]
                     |> Query.index 0
                     |> Query.contains [ Html.text (t PartnersTitle) ]
         , test "Has expected h3 heading" <|
             \_ ->
-                viewBodyHtml viewParamsWithPartner
+                viewBodyHtml eventsModel viewParamsWithPartner
                     |> Query.findAll [ Selector.tag "h3" ]
                     |> Query.index 0
                     |> Query.contains [ Html.text "Partner name" ]
         , test "Has partner description text" <|
             \_ ->
-                viewBodyHtml viewParamsWithPartner
+                viewBodyHtml eventsModel viewParamsWithPartner
                     |> Query.contains [ Html.text "Partner description" ]
 
         -- Below: can't figure out how to get it to do multiline text so leaving it for now.
         , test "Contains address if provided" <|
             \_ ->
-                viewBodyHtml viewParamsWithPartner
+                viewBodyHtml eventsModel viewParamsWithPartner
                     |> Query.has
                         [ Selector.tag "address"
                         , Selector.containing
@@ -129,12 +138,12 @@ suite =
                         ]
         , test "Contains address empty text if not provided" <|
             \_ ->
-                viewBodyHtml viewParamsWithoutMaybes
+                viewBodyHtml eventsModel viewParamsWithoutMaybes
                     |> Query.contains
                         [ Html.text (t PartnerAddressEmptyText) ]
         , test "Contact details contain url if provided" <|
             \_ ->
-                viewBodyHtml viewParamsWithPartner
+                viewBodyHtml eventsModel viewParamsWithPartner
                     |> Query.has
                         [ Selector.tag "address"
                         , Selector.containing
@@ -150,7 +159,7 @@ suite =
                         ]
         , test "Can have contact details without url" <|
             \_ ->
-                viewBodyHtml viewParamsWithoutMaybes
+                viewBodyHtml eventsModel viewParamsWithoutMaybes
                     |> Query.has
                         [ Selector.tag "address"
                         , Selector.containing
@@ -173,7 +182,7 @@ suite =
         --             |> Query.contains [ Html.text "[fFf] Map" ]
         , test "Can contain events" <|
             \_ ->
-                viewBodyHtml viewParamsWithPartner
+                viewBodyHtml eventsModel viewParamsWithPartner
                     -- Todo just testing for event name for now
                     |> Query.contains
                         [ Html.text "Event 1 name"
@@ -181,12 +190,12 @@ suite =
                         ]
         , test "Contains events empty text if no current events" <|
             \_ ->
-                viewBodyHtml viewParamsWithoutEvents
+                viewBodyHtml eventsModel viewParamsWithoutEvents
                     |> Query.contains
                         [ Html.text (t (PartnerEventsEmptyText "Partner name")) ]
         , test "Contains link back to partners page" <|
             \_ ->
-                viewBodyHtml viewParamsWithPartner
+                viewBodyHtml eventsModel viewParamsWithPartner
                     |> Query.find
                         [ Selector.tag "a"
                         , Selector.attribute (Html.Attributes.href (TransRoutes.toAbsoluteUrl Partners))


### PR DESCRIPTION
Fixes #206

## Description

- Adds filter by day controls to events on partner listing if partner has more than 20 events in total

NOTE: We default to events Today even if there are not any events today. This might not be best UX
