### PR TITLE
Bug: validate URLs coming from API.

### DIFF
--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -362,8 +362,9 @@ urlToDisplay url =
 
 isValidUrl : String -> Bool
 isValidUrl urlString =
-    String.startsWith "https:"
-        (String.toLower urlString)
-
-
+    case Url.fromString urlString of
+        Just url ->
+            url.protocol == Url.Https
+        Nothing ->
+            False
 

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -367,4 +367,3 @@ isValidUrl urlString =
 
 
 
--- (Maybe.withDefault "" urlString))

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -1,4 +1,4 @@
-module Copy.Text exposing (t, urlToDisplay)
+module Copy.Text exposing (isValidUrl, t, urlToDisplay)
 
 import Copy.Keys exposing (Key(..))
 import Url
@@ -358,3 +358,13 @@ chompTrailingUrlSlash urlString =
 urlToDisplay : String -> String
 urlToDisplay url =
     Url.fromString url |> urlRecombiner |> chompTrailingUrlSlash
+
+
+isValidUrl : String -> Bool
+isValidUrl urlString =
+    String.startsWith "https:"
+        (String.toLower urlString)
+
+
+
+-- (Maybe.withDefault "" urlString))

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -365,6 +365,6 @@ isValidUrl urlString =
     case Url.fromString urlString of
         Just url ->
             url.protocol == Url.Https
+
         Nothing ->
             False
-

--- a/src/Page/Events/Event_.elm
+++ b/src/Page/Events/Event_.elm
@@ -1,7 +1,7 @@
 module Page.Events.Event_ exposing (Data, Model, Msg, page, view)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (t, urlToDisplay)
+import Copy.Text exposing (isValidUrl, t, urlToDisplay)
 import Css exposing (Style, auto, backgroundColor, batch, borderRadius, calc, center, color, displayFlex, em, flexStart, fontSize, fontStyle, fontWeight, height, int, justifyContent, letterSpacing, margin2, margin4, marginBlockEnd, marginBlockStart, marginBottom, marginRight, marginTop, maxWidth, minus, normal, padding, pct, property, px, rem, textAlign, textTransform, uppercase, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -170,7 +170,14 @@ viewAddressSection event =
                     text ""
             , case event.partner.maybeUrl of
                 Just url ->
-                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ Theme.Global.linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+                    if isValidUrl url then
+                        p [ css [ contactItemStyle ] ]
+                            [ a [ href url, target "_blank", css [ Theme.Global.linkStyle ] ]
+                                [ text (Copy.Text.urlToDisplay url) ]
+                            ]
+
+                    else
+                        text ""
 
                 Nothing ->
                     text ""

--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -2,7 +2,7 @@ module Page.News exposing (Data, Model, Msg, page, view, viewNewsArticle)
 
 import Array exposing (Array)
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (t)
+import Copy.Text exposing (isValidUrl, t)
 import Css exposing (Style, after, auto, backgroundColor, batch, borderBox, borderRadius, boxSizing, calc, center, color, displayFlex, em, flexGrow, fontSize, fontStyle, fontWeight, height, int, italic, left, lineHeight, margin, margin2, margin4, marginBottom, marginTop, maxWidth, minus, padding, padding4, paddingLeft, pct, position, property, px, relative, rem, textAlign, width)
 import Data.PlaceCal.Articles
 import Data.PlaceCal.Partners
@@ -162,10 +162,19 @@ summaryFromArticleBody articleBody =
 
 
 newsArticleImage : Maybe String -> Html msg
-newsArticleImage maybeImage =
+newsArticleImage maybeImageUrl =
     let
         imageSource =
-            Maybe.withDefault "/images/news/article_1.jpg" maybeImage
+            case maybeImageUrl of
+                Just imageUrl ->
+                    if isValidUrl imageUrl then
+                        imageUrl
+
+                    else
+                        "/images/news/article_1.jpg"
+
+                Nothing ->
+                    "/images/news/article_1.jpg"
     in
     img [ src imageSource, css [ newsImageStyle ], alt "" ] []
 

--- a/src/Page/News/NewsItem_.elm
+++ b/src/Page/News/NewsItem_.elm
@@ -136,7 +136,6 @@ articleImage : Maybe String -> Html Msg
 articleImage maybeImageUrl =
     let
         imageSource =
-            -- Maybe.withDefault "/images/news/article_6.jpg" maybeImageUrl
             case maybeImageUrl of
                 Just imageUrl ->
                     if isValidUrl imageUrl then

--- a/src/Page/News/NewsItem_.elm
+++ b/src/Page/News/NewsItem_.elm
@@ -1,7 +1,7 @@
 module Page.News.NewsItem_ exposing (..)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (t)
+import Copy.Text exposing (isValidUrl, t)
 import Css exposing (Style, after, auto, batch, block, bold, borderRadius, center, display, firstChild, fontSize, fontStyle, fontWeight, height, italic, margin, margin2, margin4, marginTop, maxWidth, pct, property, px, rem, textAlign, width)
 import Css.Global exposing (descendants, typeSelector)
 import Data.PlaceCal.Articles
@@ -136,7 +136,17 @@ articleImage : Maybe String -> Html Msg
 articleImage maybeImageUrl =
     let
         imageSource =
-            Maybe.withDefault "/images/news/article_6.jpg" maybeImageUrl
+            -- Maybe.withDefault "/images/news/article_6.jpg" maybeImageUrl
+            case maybeImageUrl of
+                Just imageUrl ->
+                    if isValidUrl imageUrl then
+                        imageUrl
+
+                    else
+                        "/images/news/article_1.jpg"
+
+                Nothing ->
+                    "/images/news/article_1.jpg"
     in
     figure [ css [ articleFigureStyle ] ]
         [ img [ src imageSource, css [ articleFigureImageStyle ], alt "" ] []

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -1,7 +1,7 @@
 module Page.Partners.Partner_ exposing (Data, Model, Msg, page, view)
 
 import Copy.Keys exposing (Key(..))
-import Copy.Text exposing (t)
+import Copy.Text exposing (isValidUrl, t)
 import Css exposing (Style, auto, batch, calc, center, color, display, displayFlex, fontStyle, height, important, inlineBlock, margin2, margin4, marginBlockEnd, marginBlockStart, marginTop, maxWidth, minus, normal, paddingTop, pct, property, px, rem, textAlign, width)
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -173,7 +173,11 @@ viewContactDetails maybeUrl contactDetails =
             text ""
         , case maybeUrl of
             Just url ->
-                p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+                if isValidUrl url then
+                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+
+                else
+                    text ""
 
             Nothing ->
                 text ""
@@ -199,13 +203,17 @@ partnerLogo : Maybe String -> String -> Html msg
 partnerLogo maybeLogoUrl partnerName =
     case maybeLogoUrl of
         Just logoUrl ->
-            div [ css [ partnerLogoContainer ] ]
-                [ img [ src logoUrl, css [ partnerLogoStyle ], alt (partnerName ++ " logo") ] []
-                , hr [ css [ hrStyle ] ] []
-                ]
+            if isValidUrl logoUrl then
+                div [ css [ partnerLogoContainer ] ]
+                    [ img [ src logoUrl, css [ partnerLogoStyle ], alt (partnerName ++ " logo") ] []
+                    , hr [ css [ hrStyle ] ] []
+                    ]
+
+            else
+                text ""
 
         Nothing ->
-            div [] []
+            text ""
 
 
 


### PR DESCRIPTION
Closes #309 

Only allow URLs with HTTPS schema.

Models:
- Partner (url, logo)
- Event (n/a at the moment)
- NewsItem (image)

Views:
- Partner: index, show
- Event: show (uses parter.url)
- News: index, show

