### PR TITLE
Filter events by the past as well as the future

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -64,7 +64,8 @@ type Key
     | EventsEmptyText
     | EventsFilterLabelToday
     | EventsFilterLabelTomorrow
-    | EventsFilterLabelAll
+    | EventsFilterLabelAllPast
+    | EventsFilterLabelAllFuture
       --- Event Page
     | EventTitle String
     | EventMetaDescription String String

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -188,8 +188,11 @@ t key =
         EventsFilterLabelTomorrow ->
             "Tomorrow"
 
-        EventsFilterLabelAll ->
-            "All future events"
+        EventsFilterLabelAllPast ->
+            "Past events"
+
+        EventsFilterLabelAllFuture ->
+            "Future events"
 
         --- Event Page
         EventTitle eventName ->

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), afterDate, emptyEvent, eventsData, eventsFromDate, eventsFromPartnerId, next4Events)
+module Data.PlaceCal.Events exposing (Event, EventPartner, Realm(..), afterDate, emptyEvent, eventsData, eventsFromDate, eventsFromPartnerId, next4Events, onOrBeforeDate)
 
 import Api
 import DataSource
@@ -89,6 +89,15 @@ eventsFromDate eventsList fromDate =
     List.filter
         (\event ->
             TransDate.isSameDay event.startDatetime fromDate
+        )
+        eventsList
+
+
+onOrBeforeDate : List Event -> Time.Posix -> List Event
+onOrBeforeDate eventsList fromDate =
+    List.filter
+        (\event ->
+            TransDate.isOnOrBeforeDate event.startDatetime fromDate
         )
         eventsList
 

--- a/src/Helpers/TransDate.elm
+++ b/src/Helpers/TransDate.elm
@@ -5,6 +5,7 @@ module Helpers.TransDate exposing
     , humanShortMonthFromPosix
     , humanTimeFromPosix
     , isAfterDate
+    , isOnOrBeforeDate
     , isSameDay
     , isoDateStringDecoder
     )
@@ -54,6 +55,11 @@ isSameDay aDay anotherDay =
         == Time.toMonth Time.utc anotherDay
         && Time.toYear Time.utc aDay
         == Time.toYear Time.utc anotherDay
+
+
+isOnOrBeforeDate : Time.Posix -> Time.Posix -> Bool
+isOnOrBeforeDate aDay anotherDay =
+    Time.posixToMillis aDay <= Time.posixToMillis anotherDay
 
 
 isAfterDate : Time.Posix -> Time.Posix -> Bool

--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -13,7 +13,7 @@ import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, div, h1, h2, img, p, section, text)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import Page exposing (Page, StaticPayload)
-import Page.Events exposing (addPartnerNamesToEvents, viewEventsList)
+import Page.Events
 import Page.News
 import Pages.PageUrl exposing (PageUrl)
 import Pages.Url
@@ -56,7 +56,7 @@ data =
                         )
                         newsData.allArticles
                     )
-            , allEvents = addPartnerNamesToEvents eventData.allEvents partnerData
+            , allEvents = Page.Events.addPartnerNamesToEvents eventData.allEvents partnerData
             }
         )
         Data.PlaceCal.Events.eventsData
@@ -129,8 +129,7 @@ viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Html msg
 viewFeatured fromTime eventList =
     section [ css [ sectionStyle, darkBlueBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ Theme.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
-        , viewEventsList Nothing
-            (Data.PlaceCal.Events.next4Events eventList fromTime)
+        , Page.Events.viewFutureEventsList (Data.PlaceCal.Events.next4Events eventList fromTime)
         , p [ css [ buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]
             [ a
                 [ href (TransRoutes.toAbsoluteUrl Events)

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -135,7 +135,7 @@ viewInfo { partner, events } =
             ]
         , if List.length events > 0 then
             -- Might move away from sharing render, but for now hardcoding model
-            Page.Events.viewEventsList Nothing events
+            Page.Events.viewFutureEventsList events
 
           else
             p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]

--- a/tests/Page/EventsTests.elm
+++ b/tests/Page/EventsTests.elm
@@ -5,7 +5,7 @@ import Copy.Text exposing (t)
 import Data.TestFixtures as Fixtures exposing (sharedModelInit)
 import Expect
 import Html
-import Page.Events exposing (view)
+import Page.Events exposing (Filter(..), view)
 import Path
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
@@ -23,7 +23,7 @@ viewParamsWithEvents =
 
 
 eventsModel =
-    { filterByDay = Nothing
+    { filterBy = Future
     , visibleEvents = Fixtures.events
     , nowTime = Time.millisToPosix 0
     , viewportWidth = 1920
@@ -31,7 +31,7 @@ eventsModel =
 
 
 eventsModelNoEvents =
-    { filterByDay = Nothing
+    { filterBy = Future
     , visibleEvents = []
     , nowTime = Time.millisToPosix 0
     , viewportWidth = 1920


### PR DESCRIPTION
Fixes #282

Builds on #307, review and merge that first.

## Description

We add a "Past events" button to the interface.

In order to do this, I also improved the interface for the filters to rely on a custom `Filter` type instead of a `Maybe` for more expressive filtering.

I also wrapped the event list we expose to other parts of the app so it doesn't need to worry about the filtering and just provides the events.
