### PR TITLE
Scroll to events

### DIFF
--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -28,10 +28,16 @@ import View exposing (View)
 
 
 type alias Model =
-    { filterBy : Paginator.Filter
-    , visibleEvents : List Data.PlaceCal.Events.Event
-    , nowTime : Time.Posix
-    , viewportWidth : Float
+    ViewModel
+        { viewportWidth : Float
+        }
+
+
+type alias ViewModel extends =
+    { extends
+        | filterBy : Paginator.Filter
+        , visibleEvents : List Data.PlaceCal.Events.Event
+        , nowTime : Time.Posix
     }
 
 
@@ -210,11 +216,13 @@ view maybeUrl sharedModel localModel static =
     }
 
 
-viewEvents : Model -> Html Msg
-viewEvents localModel =
+viewEvents :
+    ViewModel any
+    -> Html Msg
+viewEvents viewModel =
     section [ css [ eventsContainerStyle ] ]
-        [ Paginator.viewPagination localModel
-        , viewFilteredEventsList localModel.filterBy localModel.visibleEvents
+        [ Paginator.viewPagination viewModel
+        , viewFilteredEventsList viewModel.filterBy viewModel.visibleEvents
         ]
 
 

--- a/src/Page/Events/Event_.elm
+++ b/src/Page/Events/Event_.elm
@@ -212,8 +212,12 @@ viewAddressSection event =
 viewButtons : Data.PlaceCal.Events.Event -> Html msg
 viewButtons event =
     section [ css [ buttonsStyle ] ]
-        [ Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl (Partner event.partner.id)) (t (BackToPartnerEventsLinkText event.partner.name))
-        , Theme.Global.viewBackButton (TransRoutes.toAbsoluteUrl Events) (t BackToEventsLinkText)
+        [ Theme.Global.viewBackButton
+            (TransRoutes.toAbsoluteUrl (Partner event.partner.id) ++ "#events")
+            (t (BackToPartnerEventsLinkText event.partner.name))
+        , Theme.Global.viewBackButton
+            (TransRoutes.toAbsoluteUrl Events)
+            (t BackToEventsLinkText)
         ]
 
 

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -31,6 +31,7 @@ type alias Model =
     , visibleEvents : List Data.PlaceCal.Events.Event
     , nowTime : Time.Posix
     , viewportWidth : Float
+    , urlFragment : Maybe String
     }
 
 
@@ -52,6 +53,7 @@ init maybeUrl sharedModel static =
       , visibleEvents = static.data.events
       , nowTime = Time.millisToPosix 0
       , viewportWidth = 320
+      , urlFragment = Maybe.andThen .fragment maybeUrl
       }
     , Cmd.batch
         [ Task.perform GetTime Time.now

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -240,16 +240,16 @@ viewInfo localModel { partner, events } =
         , hr [ css [ hrStyle ] ] []
         , section []
             [ h3 [ css [ smallInlineTitleStyle, color white ] ] [ text (t (PartnerUpcomingEventsText partner.name)) ]
+            , if List.length events > 0 then
+                if List.length events > 20 then
+                    Page.Events.viewEvents localModel
+
+                else
+                    Page.Events.viewEventsList events
+
+              else
+                p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]
             ]
-        , if List.length events > 0 then
-            if List.length events > 20 then
-                Page.Events.viewEvents localModel
-
-            else
-                Page.Events.viewEventsList events
-
-          else
-            p [ css [ introTextLargeStyle, color pink, important (maxWidth (px 636)) ] ] [ text (t (PartnerEventsEmptyText partner.name)) ]
         , case partner.maybeGeo of
             Just geo ->
                 div [ css [ mapContainerStyle ] ]

--- a/tests/Page/EventTests.elm
+++ b/tests/Page/EventTests.elm
@@ -4,7 +4,9 @@ import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (t)
 import Data.TestFixtures exposing (sharedModelInit)
 import Expect
+import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html
+import Html.Attributes
 import Page.Events.Event_ exposing (view)
 import Path
 import Test exposing (Test, describe, test)
@@ -94,5 +96,17 @@ suite =
         , test "Contains link back to events page" <|
             \_ ->
                 viewBodyHtml viewParamsWithEvent
+                    |> Query.find
+                        [ Selector.tag "a"
+                        , Selector.attribute (Html.Attributes.href (TransRoutes.toAbsoluteUrl Events))
+                        ]
                     |> Query.contains [ Html.text (t BackToEventsLinkText) ]
+        , test "Contains link back to events section of partner page" <|
+            \_ ->
+                viewBodyHtml viewParamsWithEvent
+                    |> Query.find
+                        [ Selector.tag "a"
+                        , Selector.attribute (Html.Attributes.href (TransRoutes.toAbsoluteUrl (Partner viewParamsWithEvent.data.partner.id) ++ "#events"))
+                        ]
+                    |> Query.contains [ Html.text (t (BackToPartnerEventsLinkText viewParamsWithEvent.data.partner.name)) ]
         ]

--- a/tests/Page/PartnerTests.elm
+++ b/tests/Page/PartnerTests.elm
@@ -96,6 +96,7 @@ eventsModel =
     , visibleEvents = Fixtures.events
     , nowTime = Time.millisToPosix 0
     , viewportWidth = 1920
+    , urlFragment = Nothing
     }
 
 


### PR DESCRIPTION
Closes #240

## Description

When clicking the "Events by <partner name>" button on an events page, we now navigate to the events section of the partner page instead of the top of the page.
