### PR TITLE
Link news list item titles to news items

### DIFF
--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -142,7 +142,7 @@ viewFeatured fromTime eventList =
 
 viewLatestNews : Maybe Data.PlaceCal.Articles.Article -> String -> String -> Html msg
 viewLatestNews maybeNewsItem title buttonText =
-    section [ css [ sectionStyle, whiteBackgroundStyle, newsSectionStyle ] ]
+    section [ css [ sectionStyle, darkBlueBackgroundStyle, newsSectionStyle ] ]
         [ h2 [ css [ Theme.smallFloatingTitleStyle ] ] [ text title ]
         , case maybeNewsItem of
             Just news ->

--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -3,7 +3,7 @@ module Page.News exposing (Data, Model, Msg, page, view, viewNewsArticle)
 import Array exposing (Array)
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (isValidUrl, t)
-import Css exposing (Style, after, auto, backgroundColor, batch, borderBox, borderRadius, boxSizing, calc, center, color, displayFlex, em, flexGrow, fontSize, fontStyle, fontWeight, height, int, italic, left, lineHeight, margin, margin2, margin4, marginBottom, marginTop, maxWidth, minus, padding, padding4, paddingLeft, pct, position, property, px, relative, rem, textAlign, width)
+import Css exposing (Style, after, auto, batch, borderBox, borderRadius, boxSizing, calc, center, displayFlex, em, flexGrow, fontSize, fontStyle, fontWeight, height, int, italic, left, lineHeight, margin, margin2, margin4, marginBottom, marginTop, maxWidth, minus, padding, padding4, paddingLeft, pct, position, property, px, relative, rem, textAlign, width)
 import Data.PlaceCal.Articles
 import Data.PlaceCal.Partners
 import DataSource exposing (DataSource)
@@ -15,7 +15,7 @@ import Html.Styled.Attributes exposing (alt, css, href, src)
 import Page exposing (Page, StaticPayload)
 import Pages.PageUrl exposing (PageUrl)
 import Shared
-import Theme.Global exposing (buttonFloatingWrapperStyle, darkBlue, pinkButtonOnLightBackgroundStyle, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.Global exposing (buttonFloatingWrapperStyle, darkBlueBackgroundStyle, linkStyle, pinkButtonOnLightBackgroundStyle, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.PageTemplate as PageTemplate
 import View exposing (View)
 
@@ -188,9 +188,8 @@ newsArticleImage maybeImageUrl =
 newsItemStyle : Style
 newsItemStyle =
     batch
-        [ margin4 (rem 2) (rem 0) (rem 3) (rem 0)
-        , backgroundColor white
-        , color darkBlue
+        [ darkBlueBackgroundStyle
+        , margin4 (rem 2) (rem 0) (rem 3) (rem 0)
         , borderRadius (rem 0.2)
         , padding4 (rem 1.25) (rem 1.25) (rem 3) (rem 1.25)
         , position relative

--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -129,7 +129,16 @@ viewNewsArticle newsItem =
     article [ css [ newsItemArticleStyle ] ]
         [ newsArticleImage newsItem.maybeImage
         , div [ css [ newsItemInfoStyle ] ]
-            [ h3 [ css [ newsItemTitleStyle ] ] [ text newsItem.title ]
+            [ h3 [ css [ newsItemTitleStyle ] ]
+                [ a
+                    [ css [ linkStyle ]
+                    , href
+                        (TransRoutes.toAbsoluteUrl
+                            (NewsItem (TransRoutes.stringToSlug newsItem.title))
+                        )
+                    ]
+                    [ text newsItem.title ]
+                ]
             , p [ css [ newsItemMetaStyle ] ]
                 [ if List.length newsItem.partnerIds > 0 then
                     span [ css [ newsItemAuthorStyle ] ]

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -1,4 +1,4 @@
-module Theme.Global exposing (backgroundColorTransition, black, blue, blueBackgroundStyle, borderTransition, buttonFloatingWrapperStyle, checkboxStyle, colorTransition, containerContent, containerPage, contentContainerStyle, contentWrapperStyle, darkBlue, darkBlueBackgroundStyle, darkBlueButtonStyle, darkBlueRgbColor, darkPurple, generateId, globalStyles, gridStyle, hrStyle, introTextLargeStyle, introTextSmallStyle, lightPink, linkStyle, mapImage, mapImageMulti, maxMobile, maxTabletPortrait, normalFirstParagraphStyle, oneColumn, pink, pinkBackgroundStyle, pinkButtonOnDarkBackgroundStyle, pinkButtonOnLightBackgroundStyle, pinkRgbColor, purple, smallFloatingTitleStyle, smallInlineTitleStyle, textBoxInvisibleStyle, textBoxPinkStyle, textBoxStyle, textInputErrorStyle, textInputStyle, threeColumn, twoColumn, verticalSpacing, viewBackButton, viewCheckbox, viewSearchInput, viewSelect, white, whiteBackgroundStyle, whiteButtonStyle, withMediaLargeDesktopUp, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+module Theme.Global exposing (backgroundColorTransition, black, blue, blueBackgroundStyle, borderTransition, buttonFloatingWrapperStyle, checkboxStyle, colorTransition, containerContent, containerPage, contentContainerStyle, contentWrapperStyle, darkBlue, darkBlueBackgroundStyle, darkBlueButtonStyle, darkBlueRgbColor, darkPurple, generateId, globalStyles, gridStyle, hrStyle, introTextLargeStyle, introTextSmallStyle, lightPink, linkStyle, mapImage, mapImageMulti, maxMobile, maxTabletPortrait, normalFirstParagraphStyle, oneColumn, pink, pinkBackgroundStyle, pinkButtonOnDarkBackgroundStyle, pinkButtonOnLightBackgroundStyle, pinkRgbColor, purple, smallFloatingTitleStyle, smallInlineTitleStyle, textBoxInvisibleStyle, textBoxPinkStyle, textBoxStyle, textInputErrorStyle, textInputStyle, threeColumn, twoColumn, verticalSpacing, viewBackButton, viewCheckbox, viewSearchInput, viewSelect, white, whiteButtonStyle, withMediaLargeDesktopUp, withMediaMediumDesktopUp, withMediaMobileOnly, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 
 import Color
 import Css exposing (Color, Style, absolute, active, after, alignItems, auto, backgroundColor, backgroundImage, backgroundRepeat, backgroundSize, batch, before, block, borderBottomColor, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderRadius, borderStyle, borderWidth, bottom, boxSizing, calc, center, color, cursor, display, displayFlex, em, firstChild, fitContent, flexDirection, flexWrap, focus, fontFamilies, fontSize, fontStyle, fontWeight, height, hex, hidden, hover, inlineBlock, int, italic, justifyContent, left, letterSpacing, lineHeight, listStyleType, margin, margin2, margin4, marginBlockEnd, marginBlockStart, marginRight, marginTop, maxContent, maxWidth, minus, none, opacity, outline, overflow, padding, padding2, padding4, paddingBottom, paddingLeft, paddingRight, pct, pointer, position, property, pseudoClass, pseudoElement, px, relative, rem, repeat, right, row, sansSerif, solid, start, textAlign, textDecoration, textTransform, top, transparent, uppercase, url, width, wrap, zero)
@@ -268,14 +268,6 @@ darkBlueBackgroundStyle =
         , borderColor pink
         , borderStyle solid
         , borderWidth (px 1)
-        ]
-
-
-whiteBackgroundStyle : Style
-whiteBackgroundStyle =
-    batch
-        [ backgroundColor white
-        , color darkBlue
         ]
 
 


### PR DESCRIPTION
Closes #243

## Description

- We give news items a dark blue background for consistency with the expanded news item page and the rest of the site and because we have established styles for links on non-white backgrounds
- We link from the title of the news list item to the news item page

I decided not to hide one of the links from screen readers because there's a bunch of the news article text in the middle, making it valuable to have both links announced. They go to the same place, but have different link text, so we don't have the issue of repetitive links.
