### PR TITLE
Select default news image based on article length

### DIFF
--- a/src/Page/News.elm
+++ b/src/Page/News.elm
@@ -1,6 +1,5 @@
 module Page.News exposing (Data, Model, Msg, page, view, viewNewsArticle)
 
-import Array exposing (Array)
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (isValidUrl, t)
 import Css exposing (Style, after, auto, backgroundColor, batch, borderBox, borderRadius, boxSizing, calc, center, color, displayFlex, em, flexGrow, fontSize, fontStyle, fontWeight, height, int, italic, left, lineHeight, margin, margin2, margin4, marginBottom, marginTop, maxWidth, minus, padding, padding4, paddingLeft, pct, position, property, px, relative, rem, textAlign, width)
@@ -13,6 +12,7 @@ import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, article, div, h3, img, li, p, section, span, text, time, ul)
 import Html.Styled.Attributes exposing (alt, css, href, src)
 import Page exposing (Page, StaticPayload)
+import Page.News.NewsItem_
 import Pages.PageUrl exposing (PageUrl)
 import Shared
 import Theme.Global exposing (buttonFloatingWrapperStyle, darkBlue, pinkButtonOnLightBackgroundStyle, white, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
@@ -106,18 +106,6 @@ viewNewsList news =
         ]
 
 
-defaultNewsImages : Array String
-defaultNewsImages =
-    Array.fromList
-        [ "/images/news/article_1.jpg"
-        , "/images/news/article_2.jpg"
-        , "/images/news/article_3.jpg"
-        , "/images/news/article_4.jpg"
-        , "/images/news/article_5.jpg"
-        , "/images/news/article_6.jpg"
-        ]
-
-
 viewNewsItem : Data.PlaceCal.Articles.Article -> Html msg
 viewNewsItem newsItem =
     li [ css [ newsItemStyle ] ]
@@ -127,7 +115,7 @@ viewNewsItem newsItem =
 viewNewsArticle : Data.PlaceCal.Articles.Article -> Html msg
 viewNewsArticle newsItem =
     article [ css [ newsItemArticleStyle ] ]
-        [ newsArticleImage newsItem.maybeImage
+        [ newsArticleImage newsItem.maybeImage newsItem.body
         , div [ css [ newsItemInfoStyle ] ]
             [ h3 [ css [ newsItemTitleStyle ] ] [ text newsItem.title ]
             , p [ css [ newsItemMetaStyle ] ]
@@ -161,22 +149,14 @@ summaryFromArticleBody articleBody =
         |> String.join " "
 
 
-newsArticleImage : Maybe String -> Html msg
-newsArticleImage maybeImageUrl =
-    let
-        imageSource =
-            case maybeImageUrl of
-                Just imageUrl ->
-                    if isValidUrl imageUrl then
-                        imageUrl
-
-                    else
-                        "/images/news/article_1.jpg"
-
-                Nothing ->
-                    "/images/news/article_1.jpg"
-    in
-    img [ src imageSource, css [ newsImageStyle ], alt "" ] []
+newsArticleImage : Maybe String -> String -> Html msg
+newsArticleImage maybeImage articleBody =
+    img
+        [ src (Page.News.NewsItem_.articleImageSource maybeImage articleBody)
+        , css [ newsImageStyle ]
+        , alt ""
+        ]
+        []
 
 
 

--- a/src/Page/News/NewsItem_.elm
+++ b/src/Page/News/NewsItem_.elm
@@ -1,5 +1,6 @@
 module Page.News.NewsItem_ exposing (..)
 
+import Array exposing (Array)
 import Copy.Keys exposing (Key(..))
 import Copy.Text exposing (isValidUrl, t)
 import Css exposing (Style, after, auto, batch, block, bold, borderRadius, center, display, firstChild, fontSize, fontStyle, fontWeight, height, italic, margin, margin2, margin4, marginTop, maxWidth, pct, property, px, rem, textAlign, width)
@@ -127,28 +128,53 @@ viewArticle newsItem =
                 text ""
             , time [] [ text (TransDate.humanDateFromPosix newsItem.publishedDatetime) ]
             ]
-        , articleImage newsItem.maybeImage
+        , articleImage newsItem.maybeImage newsItem.body
         , div [ css [ articleContentStyle ] ] [ text newsItem.body ]
         ]
 
 
-articleImage : Maybe String -> Html Msg
-articleImage maybeImageUrl =
-    let
-        imageSource =
-            case maybeImageUrl of
-                Just imageUrl ->
-                    if isValidUrl imageUrl then
-                        imageUrl
-
-                    else
-                        "/images/news/article_1.jpg"
-
-                Nothing ->
-                    "/images/news/article_1.jpg"
-    in
+articleImage : Maybe String -> String -> Html Msg
+articleImage maybeImage articleBody =
     figure [ css [ articleFigureStyle ] ]
-        [ img [ src imageSource, css [ articleFigureImageStyle ], alt "" ] []
+        [ img [ src (articleImageSource maybeImage articleBody), css [ articleFigureImageStyle ], alt "" ] []
+        ]
+
+
+articleImageSource : Maybe String -> String -> String
+articleImageSource maybeImage articleBody =
+    let
+        defaultImageUrl =
+            Maybe.withDefault
+                "/images/news/article_1.jpg"
+                (Array.get
+                    (modBy
+                        (Array.length defaultNewsImages)
+                        (String.length articleBody)
+                    )
+                    defaultNewsImages
+                )
+    in
+    case maybeImage of
+        Just imageUrl ->
+            if isValidUrl imageUrl then
+                imageUrl
+
+            else
+                defaultImageUrl
+
+        Nothing ->
+            defaultImageUrl
+
+
+defaultNewsImages : Array String
+defaultNewsImages =
+    Array.fromList
+        [ "/images/news/article_1.jpg"
+        , "/images/news/article_2.jpg"
+        , "/images/news/article_3.jpg"
+        , "/images/news/article_4.jpg"
+        , "/images/news/article_5.jpg"
+        , "/images/news/article_6.jpg"
         ]
 
 


### PR DESCRIPTION
Relates to #137

I chose article length because it looks like the existing articles all have the same publication datetime (probably because they're published at midnight or something). Article length felt random enough to create a decent amount of variation.