### PR TITLE
update information about test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ We recommend integrating `elm-format@0.8.3` into your code editor, but if you do
 
 ## Testing
 
-We're using [elm-test-rs](https://github.com/mpizenberg/elm-test-rs) to run [elm tests](https://package.elm-lang.org/packages/elm-explorations/test/latest/)
+We're using [elm-test-rs](https://github.com/mpizenberg/elm-test-rs) to run [elm tests](https://package.elm-lang.org/packages/elm-explorations/test/latest/). It is required to run either `npm start` (quickest) or `npm build` at least once in the project before tests will work.
 
--  run tests with `npm test`
+- run tests with `npm test`
 
 ## Code & configs
 


### PR DESCRIPTION
Fixes #295

## Description

- Updated README with instructions on how to run tests. I looked into modifying the npm script for testing but decided it was not an improvement for the reasons below.

```
		"test": "elm-constants && elm-pages build && elm-test-rs"
```

Took `1054.63s user 31.08s system 116% cpu 15:32.05 total` which is too long to run each time.

```
		"test": "elm-constants  && elm-pages dev --port 3030 && elm-test-rs"
```

Did not provide the test results in the terminal.

Running `npm start` before `npm test` is both quick and allows the tests to work. It does not need to be running each time the tests are called.