### PR TITLE
Parse markdown event descriptions

### DIFF
--- a/src/Page/Events/Event_.elm
+++ b/src/Page/Events/Event_.elm
@@ -15,8 +15,9 @@ import Page exposing (Page, StaticPayload)
 import Page.Events
 import Pages.PageUrl exposing (PageUrl)
 import Shared
-import Theme.Global exposing (darkBlue, linkStyle, pink, smallInlineTitleStyle, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
+import Theme.Global exposing (darkBlue, linkStyle, normalFirstParagraphStyle, pink, smallInlineTitleStyle, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.PageTemplate as PageTemplate
+import Theme.TransMarkdown
 import View exposing (View)
 
 
@@ -142,8 +143,7 @@ viewInfoSection event =
                     text ""
             ]
         , div [ css [ eventDescriptionStyle ] ]
-            --  (Theme.TransMarkdown.markdownToHtml event.description)
-            [ p [] [ text event.description ] ]
+            (Theme.TransMarkdown.markdownToHtml event.description)
         ]
 
 
@@ -291,10 +291,13 @@ eventPartnerStyle =
 eventDescriptionStyle : Style
 eventDescriptionStyle =
     batch
-        [ marginTop (rem 1)
-        , marginBottom (rem 2)
-        , withMediaTabletLandscapeUp [ marginTop (rem 3) ]
-        , withMediaTabletPortraitUp [ marginTop (rem 2) ]
+        [ normalFirstParagraphStyle
+        , withMediaTabletLandscapeUp
+            [ margin2 (rem 2) auto
+            , maxWidth (px 636)
+            ]
+        , withMediaTabletPortraitUp
+            [ margin2 (rem 2) (rem 2) ]
         ]
 
 


### PR DESCRIPTION
We borrow the styles directly from partners.

## Description

### Before

<img width="848" alt="Screenshot 2022-10-18 at 16 43 55" src="https://user-images.githubusercontent.com/1027364/196466265-563f0edc-b206-44d1-a3df-79b88070fef9.png">

### After

<img width="1114" alt="Screenshot 2022-10-18 at 16 56 01" src="https://user-images.githubusercontent.com/1027364/196466208-55cbfa95-8ba7-42ce-9991-dd4309eb5514.png">
