### PR TITLE
add label to signup form for accessibilty

### DIFF
--- a/src/Theme/PageFooter.elm
+++ b/src/Theme/PageFooter.elm
@@ -6,7 +6,7 @@ import Css exposing (Style, active, after, alignItems, alignSelf, auto, backgrou
 import Css.Transitions exposing (transition)
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, button, div, footer, form, img, input, label, li, nav, p, span, text, ul)
-import Html.Styled.Attributes exposing (action, attribute, css, href, method, name, placeholder, src, target, type_, value)
+import Html.Styled.Attributes exposing (action, attribute, css, for, href, id, method, name, placeholder, src, target, type_, value)
 import List exposing (append, concat)
 import Theme.Global exposing (colorTransition, darkBlue, darkPurple, pink, pinkButtonOnDarkBackgroundStyle, smallInlineTitleStyle, textInputStyle, white, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.Logo
@@ -92,13 +92,14 @@ viewPageFooterSignup =
         , method "post"
         , target "_blank"
         ]
-        [ span [ css [ subheadStyle ] ] [ text (t FooterSignupText) ]
+        [ label [ for "signup", css [ subheadStyle ] ] [ text (t FooterSignupText) ]
         , div [ css [ innerFormStyle ] ]
             [ input
                 [ placeholder (t FooterSignupEmailPlaceholder)
                 , type_ "email"
                 , name "fields[email]"
                 , css [ formInputStyle ]
+                , id "signup"
                 ]
                 []
             , input [ type_ "hidden", name "ml-submit", value "1" ] []


### PR DESCRIPTION
Fixes #338 

## Description

- convert span "heading" to a label
- avoids visual regression
- doesn't *look* like a label so although it is clickable and helpful to screen readers I am not sure if someone looking at the site would attempt to use it in that way.
