### PR TITLE
add aria-labels to h1 tags which contain SVG text

### DIFF
--- a/src/Page/Index.elm
+++ b/src/Page/Index.elm
@@ -11,7 +11,7 @@ import Head
 import Head.Seo as Seo
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled exposing (Html, a, div, h1, h2, img, p, section, text)
-import Html.Styled.Attributes exposing (alt, css, href, src)
+import Html.Styled.Attributes exposing (alt, attribute, css, href, src)
 import Page exposing (Page, StaticPayload)
 import Page.Events
 import Page.News
@@ -112,7 +112,7 @@ view maybeUrl sharedModel static =
 viewIntro : String -> String -> String -> Html msg
 viewIntro introTitle introMsg eventButtonText =
     section [ css [ sectionStyle, pinkBackgroundStyle, introSectionStyle ] ]
-        [ h1 [ css [ logoStyle ] ] [ img [ src "/images/logos/tdd_logo_with_strapline.svg", alt (t SiteTitle), css [ logoImageStyle ] ] [] ]
+        [ h1 [ attribute "aria-label" (t SiteTitle ++ ", " ++ t SiteStrapline), css [ logoStyle ] ] [ img [ src "/images/logos/tdd_logo_with_strapline.svg", alt (t SiteTitle), css [ logoImageStyle ] ] [] ]
         , h2 [ css [ sectionSubtitleStyle ] ] [ text introTitle ]
         , p [ css [ sectionTextStyle ] ] [ text introMsg ]
         , p [ css [ buttonFloatingWrapperStyle, width (calc (pct 100) minus (rem 2)) ] ]

--- a/src/Theme/PageHeader.elm
+++ b/src/Theme/PageHeader.elm
@@ -6,7 +6,7 @@ import Css exposing (Style, alignItems, alignSelf, auto, backgroundColor, batch,
 import Css.Transitions exposing (transition)
 import Helpers.TransRoutes as TransRoutes exposing (..)
 import Html.Styled exposing (Html, a, button, div, h1, header, li, nav, p, span, text, ul)
-import Html.Styled.Attributes exposing (css, href)
+import Html.Styled.Attributes exposing (attribute, css, href)
 import Html.Styled.Events exposing (onClick)
 import Messages exposing (Msg(..))
 import Path exposing (Path)
@@ -44,7 +44,7 @@ viewPageHeader currentPath viewOptions =
 viewPageHeaderTitle : String -> String -> Html Msg
 viewPageHeaderTitle pageTitle strapLine =
     div [ css [ titleStyle ] ]
-        [ h1 [] [ Theme.Logo.view ]
+        [ h1 [ attribute "aria-label" (t SiteTitle ++ ", " ++ t SiteStrapline) ] [ Theme.Logo.view ]
         ]
 
 

--- a/src/Theme/PageTemplate.elm
+++ b/src/Theme/PageTemplate.elm
@@ -7,7 +7,7 @@ import Head
 import Head.Seo as Seo
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
 import Html.Styled as Html exposing (Html, a, div, h1, h2, h3, img, p, section, text)
-import Html.Styled.Attributes exposing (alt, css, href, src)
+import Html.Styled.Attributes exposing (alt, attribute, css, href, src)
 import List exposing (append)
 import Pages.Url
 import Theme.Global exposing (contentContainerStyle, contentWrapperStyle, introTextLargeStyle, introTextSmallStyle, textBoxInvisibleStyle, textBoxPinkStyle, white, withMediaMediumDesktopUp, withMediaSmallDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
@@ -114,11 +114,12 @@ view pageInfo =
 viewHeader : PageUsingTemplate msg -> Html msg
 viewHeader pageInfo =
     section [ css [ headerSectionStyle ] ]
-        [ h1 []
+        [ h1 [ attribute "aria-label" (t SiteTitle ++ ", " ++ t SiteStrapline) ]
             -- Hack to get llinkable absolute positioned header
             -- Probably needs a refactor with simplified styles
             [ a
-                [ href (TransRoutes.toAbsoluteUrl Home)
+                [ attribute "aria-label" "Home"
+                , href (TransRoutes.toAbsoluteUrl Home)
                 , css [ headerLogoAStyle, zIndex (int 99) ]
                 ]
                 [ img


### PR DESCRIPTION
Fixes #342 

## Description

- add aria-labels to `h1` tags and `a` tags that that use the svg logo

https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Text_labels_and_names#headings_should_have_visible_text_content

It looks like the use of SVG logos instead of a text node is not advised for headers so this will be unlikely to meet WCAG standards. Aria-label is not a substitute, but seeing as this is a core part of the sites design it seems unlikely that we will rework this in the near future. This at least provides screen readers with information when they hit the header for navigation.

https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/#a-word-of-caution

This also suggests that there are issues with adding links and images into headers but that is beyond the scope of this issue.