### PR TITLE
Only show partners without service areas on map

### DIFF
--- a/src/Page/Partners.elm
+++ b/src/Page/Partners.elm
@@ -116,9 +116,8 @@ viewPartner partner =
 viewMap : List Data.PlaceCal.Partners.Partner -> Html msg
 viewMap partnerList =
     let
-        allowOnlyPartnersWithLocation =
-            \partner ->
-                List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)
+        partnersIsVenueWithLocation partner =
+            List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)
 
         partnerToGeo =
             \partner ->

--- a/src/Page/Partners.elm
+++ b/src/Page/Partners.elm
@@ -118,7 +118,7 @@ viewMap partnerList =
     div [ css [ featurePlaceholderStyle ] ]
         [ Theme.mapImageMulti
             (t PartnersMapAltText)
-            (List.filter (\partner -> partner.maybeGeo /= Nothing) partnerList
+            (List.filter (\partner -> List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)) partnerList
                 |> List.map
                     (\partner ->
                         case partner.maybeGeo of

--- a/src/Page/Partners.elm
+++ b/src/Page/Partners.elm
@@ -116,8 +116,9 @@ viewPartner partner =
 viewMap : List Data.PlaceCal.Partners.Partner -> Html msg
 viewMap partnerList =
     let
-        partnersIsVenueWithLocation partner =
-            List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)
+        allowOnlyPartnersWithLocation =
+            \partner ->
+                List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)
 
         partnerToGeo =
             \partner ->

--- a/src/Page/Partners.elm
+++ b/src/Page/Partners.elm
@@ -115,23 +115,29 @@ viewPartner partner =
 
 viewMap : List Data.PlaceCal.Partners.Partner -> Html msg
 viewMap partnerList =
+    let
+        allowOnlyPartnersWithLocation =
+            \partner ->
+                List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)
+
+        partnerToGeo =
+            \partner ->
+                case partner.maybeGeo of
+                    Just geo ->
+                        { latitude = geo.latitude
+                        , longitude = geo.longitude
+                        }
+
+                    Nothing ->
+                        { latitude = "0"
+                        , longitude = "0"
+                        }
+    in
     div [ css [ featurePlaceholderStyle ] ]
         [ Theme.mapImageMulti
             (t PartnersMapAltText)
-            (List.filter (\partner -> List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)) partnerList
-                |> List.map
-                    (\partner ->
-                        case partner.maybeGeo of
-                            Just geo ->
-                                { latitude = geo.latitude
-                                , longitude = geo.longitude
-                                }
-
-                            Nothing ->
-                                { latitude = "0"
-                                , longitude = "0"
-                                }
-                    )
+            (List.filter allowOnlyPartnersWithLocation partnerList
+                |> List.map partnerToGeo
             )
         ]
 

--- a/src/Page/Partners.elm
+++ b/src/Page/Partners.elm
@@ -116,22 +116,20 @@ viewPartner partner =
 viewMap : List Data.PlaceCal.Partners.Partner -> Html msg
 viewMap partnerList =
     let
-        allowOnlyPartnersWithLocation =
-            \partner ->
-                List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)
+        allowOnlyPartnersWithLocation partner =
+            List.isEmpty partner.areasServed && (partner.maybeGeo /= Nothing)
 
-        partnerToGeo =
-            \partner ->
-                case partner.maybeGeo of
-                    Just geo ->
-                        { latitude = geo.latitude
-                        , longitude = geo.longitude
-                        }
+        partnerToGeo partner =
+            case partner.maybeGeo of
+                Just geo ->
+                    { latitude = geo.latitude
+                    , longitude = geo.longitude
+                    }
 
-                    Nothing ->
-                        { latitude = "0"
-                        , longitude = "0"
-                        }
+                Nothing ->
+                    { latitude = "0"
+                    , longitude = "0"
+                    }
     in
     div [ css [ featurePlaceholderStyle ] ]
         [ Theme.mapImageMulti


### PR DESCRIPTION
Fixes #352

On /partners only show pins on the map from partners with no service areas