### PR TITLE
Remove partner logo from show partner page

### DIFF
--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -245,7 +245,9 @@ view maybeUrl sharedModel localModel static =
 viewInfo : Model -> Data -> Html Msg
 viewInfo localModel { partner, events } =
     section [ css [ margin2 (rem 0) (rem 0.35) ] ]
-        [ partnerLogo partner.maybeLogo partner.name
+        [ text ""
+
+        --[ partnerLogo partner.maybeLogo partner.name
         , div [ css [ descriptionStyle ] ] (Theme.TransMarkdown.markdownToHtml (t (PartnerDescriptionText partner.description partner.name)))
         , hr [ css [ hrStyle ] ] []
         , section [ css [ contactWrapperStyle ] ]


### PR DESCRIPTION
Fixes #353 

This data comes from PlaceCal where partner admins can upload any arbitrary image (not just a logo) so sometimes this is a picture of their group or facilities. Furthermore: if this is a logo we don't have any way of making the logo look correct on the TD page which is important if they have a transparent PNG with dark text.
