### PR TITLE
fix: Allow for geo data to contain null Lat or Long (temporary)

### DIFF
--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -46,8 +46,11 @@ type alias EventLocation =
 
 
 type alias Geo =
-    { latitude : String
-    , longitude : String
+    -- Bug: We expect if there is a postcode in the address, these exist.
+    -- But, in practice, sometimes they don't see:
+    -- https://github.com/geeksforsocialchange/PlaceCal/issues/1639
+    { latitude : Maybe String
+    , longitude : Maybe String
     }
 
 
@@ -203,8 +206,12 @@ partnerIdDecoder =
 geoDecoder : OptimizedDecoder.Decoder Geo
 geoDecoder =
     OptimizedDecoder.succeed Geo
-        |> OptimizedDecoder.Pipeline.required "latitude" OptimizedDecoder.string
-        |> OptimizedDecoder.Pipeline.required "longitude" OptimizedDecoder.string
+        |> OptimizedDecoder.Pipeline.optional "latitude"
+            (OptimizedDecoder.nullable OptimizedDecoder.string)
+            Nothing
+        |> OptimizedDecoder.Pipeline.optional "longitude"
+            (OptimizedDecoder.nullable OptimizedDecoder.string)
+            Nothing
 
 
 type alias AllEventsResponse =

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -38,8 +38,11 @@ type alias Contact =
 
 
 type alias Geo =
-    { latitude : String
-    , longitude : String
+    -- Bug: We expect if there is a postcode in the address, these exist.
+    -- But, in practice, sometimes they don't see:
+    -- https://github.com/geeksforsocialchange/PlaceCal/issues/1639
+    { latitude : Maybe String
+    , longitude : Maybe String
     }
 
 
@@ -134,8 +137,12 @@ decodePartner =
 geoDecoder : OptimizedDecoder.Decoder Geo
 geoDecoder =
     OptimizedDecoder.succeed Geo
-        |> OptimizedDecoder.Pipeline.required "latitude" OptimizedDecoder.string
-        |> OptimizedDecoder.Pipeline.required "longitude" OptimizedDecoder.string
+        |> OptimizedDecoder.Pipeline.optional "latitude"
+            (OptimizedDecoder.nullable OptimizedDecoder.string)
+            Nothing
+        |> OptimizedDecoder.Pipeline.optional "longitude"
+            (OptimizedDecoder.nullable OptimizedDecoder.string)
+            Nothing
 
 
 contactDecoder : OptimizedDecoder.Decoder Contact

--- a/src/Page/Partners.elm
+++ b/src/Page/Partners.elm
@@ -122,13 +122,11 @@ viewMap partnerList =
         partnerToGeo partner =
             case partner.maybeGeo of
                 Just geo ->
-                    { latitude = geo.latitude
-                    , longitude = geo.longitude
-                    }
+                    geo
 
                 Nothing ->
-                    { latitude = "0"
-                    , longitude = "0"
+                    { latitude = Nothing
+                    , longitude = Nothing
                     }
     in
     div [ css [ featurePlaceholderStyle ] ]

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -609,24 +609,70 @@ generateId input =
 -- Map
 
 
-mapImageMulti : String -> List { latitude : String, longitude : String } -> Html msg
+mapImageMulti :
+    String
+    -> List { latitude : Maybe String, longitude : Maybe String }
+    -> Html msg
 mapImageMulti altText markerList =
     img
-        [ src ("https://api.mapbox.com/styles/v1/studiosquid/cl082tq5a001o14mgaatx9fze/static/" ++ String.join "," (List.map (\marker -> "pin-l+ffffff(" ++ marker.longitude ++ "," ++ marker.latitude ++ ")") markerList) ++ "/auto/1140x400@2x?access_token=pk.eyJ1Ijoic3R1ZGlvc3F1aWQiLCJhIjoiY2o5bzZmNzhvMWI2dTJ3bnQ1aHFnd3loYSJ9.NC3T07dEr_Aw7wo1O8aF-g")
+        [ src
+            ("https://api.mapbox.com/styles/v1/studiosquid/cl082tq5a001o14mgaatx9fze/static/"
+                ++ String.join ","
+                    (List.map (\marker -> "pin-l+ffffff(" ++ marker.longitude ++ "," ++ marker.latitude ++ ")") (removeNullCoords markerList))
+                ++ "/auto/1140x400@2x?access_token=pk.eyJ1Ijoic3R1ZGlvc3F1aWQiLCJhIjoiY2o5bzZmNzhvMWI2dTJ3bnQ1aHFnd3loYSJ9.NC3T07dEr_Aw7wo1O8aF-g"
+            )
         , alt altText
         , css [ mapStyle ]
         ]
         []
 
 
-mapImage : String -> { latitude : String, longitude : String } -> Html msg
+mapImage :
+    String
+    -> { latitude : Maybe String, longitude : Maybe String }
+    -> Html msg
 mapImage altText geo =
+    if geo.latitude == Nothing || geo.longitude == Nothing then
+        text ""
+
+    else
+        mapImageHtml
+            ( altText
+            , maybeLatLongToLatLongWithDefault0 geo
+            )
+
+
+mapImageHtml : ( String, { latitude : String, longitude : String } ) -> Html msg
+mapImageHtml ( altText, geo ) =
     img
         [ src ("https://api.mapbox.com/styles/v1/studiosquid/cl082tq5a001o14mgaatx9fze/static/pin-l+ffffff(" ++ geo.longitude ++ "," ++ geo.latitude ++ ")/" ++ geo.longitude ++ "," ++ geo.latitude ++ ",15,0/1140x400@2x?access_token=pk.eyJ1Ijoic3R1ZGlvc3F1aWQiLCJhIjoiY2o5bzZmNzhvMWI2dTJ3bnQ1aHFnd3loYSJ9.NC3T07dEr_Aw7wo1O8aF-g")
         , alt altText
         , css [ mapStyle ]
         ]
         []
+
+
+removeNullCoords :
+    List { latitude : Maybe String, longitude : Maybe String }
+    -> List { latitude : String, longitude : String }
+removeNullCoords markerList =
+    List.filter (\marker -> markerHasLatAndLong marker) markerList
+        |> List.map maybeLatLongToLatLongWithDefault0
+
+
+markerHasLatAndLong : { latitude : Maybe String, longitude : Maybe String } -> Bool
+markerHasLatAndLong markerData =
+    not (markerData.latitude == Nothing || markerData.longitude == Nothing)
+
+
+maybeLatLongToLatLongWithDefault0 :
+    { latitude : Maybe String, longitude : Maybe String }
+    -> { latitude : String, longitude : String }
+maybeLatLongToLatLongWithDefault0 { latitude, longitude } =
+    -- Return 0, 0 as coords if there is no data
+    { latitude = Maybe.withDefault "0" latitude
+    , longitude = Maybe.withDefault "0" longitude
+    }
 
 
 mapStyle : Style

--- a/src/Theme/Global.elm
+++ b/src/Theme/Global.elm
@@ -632,7 +632,7 @@ mapImage :
     -> { latitude : Maybe String, longitude : Maybe String }
     -> Html msg
 mapImage altText geo =
-    if geo.latitude == Nothing || geo.longitude == Nothing then
+    if not (markerHasLatAndLong geo) then
         text ""
 
     else


### PR DESCRIPTION
Fixes #379 

## Description

- Temporarily allow address values from PlaceCal to have missing lat and long
- Default to 0, 0 and do not render in maps
