### PR TITLE
Improve text shown for past events when none exist 

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -62,6 +62,7 @@ type Key
     | EventsSubHeading
     | EventsEmptyTextAll
     | EventsEmptyText
+    | PreviousEventsEmptyTextAll
     | EventsFilterLabelToday
     | EventsFilterLabelTomorrow
     | EventsFilterLabelAllPast

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -185,6 +185,9 @@ t key =
         EventsEmptyText ->
             "There are no upcoming events on this date. Check back for updates!"
 
+        PreviousEventsEmptyTextAll ->
+            "There were no past events."
+
         EventsFilterLabelToday ->
             "Today"
 

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -186,7 +186,7 @@ t key =
             "There are no upcoming events on this date. Check back for updates!"
 
         PreviousEventsEmptyTextAll ->
-            "There were no past events."
+            "There have been no events in the recent past."
 
         EventsFilterLabelToday ->
             "Today"

--- a/src/Page/Events.elm
+++ b/src/Page/Events.elm
@@ -25,6 +25,7 @@ import Theme.PageTemplate as PageTemplate
 import Theme.Paginator as Paginator exposing (Msg(..))
 import Time
 import View exposing (View)
+import Theme.Paginator exposing (Filter(..))
 
 
 type alias Model =
@@ -244,6 +245,9 @@ viewFilteredEventsList filter filteredEvents =
                     (case filter of
                         Paginator.Day _ ->
                             t EventsEmptyText
+
+                        Paginator.Past ->
+                            t PreviousEventsEmptyTextAll
 
                         _ ->
                             t EventsEmptyTextAll

--- a/tests/Page/EventsTests.elm
+++ b/tests/Page/EventsTests.elm
@@ -38,6 +38,13 @@ eventsModelNoEvents =
     , viewportWidth = 1920
     }
 
+eventsModelNoPreviousEvents =
+    { filterBy = Paginator.Past
+    , visibleEvents = []
+    , nowTime = Time.millisToPosix 0
+    , viewportWidth = 1920
+    }
+
 
 viewParamsWithoutEvents =
     { data = []
@@ -92,4 +99,8 @@ suite =
             \_ ->
                 viewBodyHtml eventsModelNoEvents viewParamsWithoutEvents
                     |> Query.contains [ Html.text (t EventsEmptyTextAll) ]
+        , test "Contains previous events empty text if there are no previous events" <|
+            \_ ->
+                viewBodyHtml eventsModelNoPreviousEvents viewParamsWithoutEvents
+                    |> Query.contains [ Html.text (t PreviousEventsEmptyTextAll) ]
         ]


### PR DESCRIPTION
Fixes #361 

## Description

- When a partner has > 20 events and `past events` is selected, if none exist then the text shown now is 

> There were no past events.

- A test has been added to catch this edge case

Please let me know what the copy should be here if this is not suitable - I just went with something simple for now!
