### PR TITLE
fix: Expect contact details to maybe be empty

### DIFF
--- a/src/Copy/Keys.elm
+++ b/src/Copy/Keys.elm
@@ -84,6 +84,7 @@ type Key
     | PartnerTitle String
     | PartnerMetaDescription String String
     | PartnerContactsHeading
+    | PartnerContactsEmptyText
     | PartnerAddressHeading
     | PartnerAddressEmptyText
     | PartnerDescriptionText String String

--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -245,6 +245,9 @@ t key =
         PartnerContactsHeading ->
             "Get in touch"
 
+        PartnerContactsEmptyText ->
+            "No contact details provided"
+
         PartnerAddressHeading ->
             "Address"
 

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -16,7 +16,7 @@ type alias Partner =
     , summary : String
     , description : String
     , maybeUrl : Maybe String
-    , contactDetails : Contact
+    , maybeContactDetails : Maybe Contact
     , maybeAddress : Maybe Address
     , areasServed : List ServiceArea
     , maybeGeo : Maybe Geo
@@ -59,7 +59,7 @@ emptyPartner =
     , summary = ""
     , description = ""
     , maybeUrl = Nothing
-    , contactDetails = { email = "", telephone = "" }
+    , maybeContactDetails = Nothing
     , maybeAddress = Nothing
     , areasServed = []
     , maybeGeo = Nothing
@@ -127,7 +127,7 @@ decodePartner =
         |> OptimizedDecoder.Pipeline.optional "summary" OptimizedDecoder.string ""
         |> OptimizedDecoder.Pipeline.required "description" OptimizedDecoder.string
         |> OptimizedDecoder.Pipeline.optional "url" (OptimizedDecoder.map Just OptimizedDecoder.string) Nothing
-        |> OptimizedDecoder.Pipeline.required "contact" contactDecoder
+        |> OptimizedDecoder.Pipeline.optional "contact" (OptimizedDecoder.map Just contactDecoder) Nothing
         |> OptimizedDecoder.Pipeline.optional "address" (OptimizedDecoder.map Just addressDecoder) Nothing
         |> OptimizedDecoder.Pipeline.required "areasServed" (OptimizedDecoder.list serviceAreaDecoder)
         |> OptimizedDecoder.Pipeline.optionalAt [ "address", "geo" ] (OptimizedDecoder.map Just geoDecoder) Nothing
@@ -189,7 +189,7 @@ eventPartnerFromId partnerList partnerId =
         |> List.map
             (\partner ->
                 { name = Just partner.name
-                , maybeContactDetails = Just partner.contactDetails
+                , maybeContactDetails = partner.maybeContactDetails
                 , id = partner.id
                 , maybeUrl = partner.maybeUrl
                 }

--- a/src/Page/Partners/Partner_.elm
+++ b/src/Page/Partners/Partner_.elm
@@ -10,7 +10,7 @@ import Data.PlaceCal.Partners
 import DataSource exposing (DataSource)
 import Head
 import Helpers.TransRoutes as TransRoutes exposing (Route(..))
-import Html.Styled exposing (Html, a, address, div, h3, hr, img, p, section, text)
+import Html.Styled exposing (Html, a, address, div, h3, hr, img, p, section, span, text)
 import Html.Styled.Attributes exposing (alt, css, href, id, src, target)
 import Page exposing (PageWithState, StaticPayload)
 import Page.Events
@@ -253,7 +253,7 @@ viewInfo localModel { partner, events } =
         , section [ css [ contactWrapperStyle ] ]
             [ div [ css [ contactSectionStyle ] ]
                 [ h3 [ css [ contactHeadingStyle, Theme.Global.smallInlineTitleStyle ] ] [ text (t PartnerContactsHeading) ]
-                , viewContactDetails partner.maybeUrl partner.contactDetails
+                , viewContactDetails partner.maybeUrl partner.maybeContactDetails
                 ]
             , div [ css [ contactSectionStyle ] ]
                 [ h3 [ css [ contactHeadingStyle, Theme.Global.smallInlineTitleStyle ] ] [ text (t PartnerAddressHeading) ]
@@ -323,34 +323,45 @@ viewPartnerEvents localModel { partner, events } =
         )
 
 
-viewContactDetails : Maybe String -> Data.PlaceCal.Partners.Contact -> Html msg
-viewContactDetails maybeUrl contactDetails =
-    address []
-        [ if String.length contactDetails.telephone > 0 then
-            p [ css [ contactItemStyle ] ] [ text contactDetails.telephone ]
+viewContactDetails : Maybe String -> Maybe Data.PlaceCal.Partners.Contact -> Html msg
+viewContactDetails maybeUrl maybeContactDetails =
+    if maybeUrl == Nothing && maybeContactDetails == Nothing then
+        p [ css [ contactItemStyle ] ] [ text (t PartnerContactsEmptyText) ]
 
-          else
-            text ""
-        , if String.length contactDetails.email > 0 then
-            p
-                [ css [ contactItemStyle ] ]
-                [ a
-                    [ href ("mailto:" ++ contactDetails.email)
-                    , css [ linkStyle ]
-                    ]
-                    [ text contactDetails.email
-                    ]
-                ]
+    else
+        address []
+            [ case maybeContactDetails of
+                Just contactDetails ->
+                    span []
+                        [ if String.length contactDetails.telephone > 0 then
+                            p [ css [ contactItemStyle ] ] [ text contactDetails.telephone ]
 
-          else
-            text ""
-        , case maybeUrl of
-            Just url ->
-                p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+                          else
+                            text ""
+                        , if String.length contactDetails.email > 0 then
+                            p
+                                [ css [ contactItemStyle ] ]
+                                [ a
+                                    [ href ("mailto:" ++ contactDetails.email)
+                                    , css [ linkStyle ]
+                                    ]
+                                    [ text contactDetails.email
+                                    ]
+                                ]
 
-            Nothing ->
-                text ""
-        ]
+                          else
+                            text ""
+                        ]
+
+                Nothing ->
+                    text ""
+            , case maybeUrl of
+                Just url ->
+                    p [ css [ contactItemStyle ] ] [ a [ href url, target "_blank", css [ linkStyle ] ] [ text (Copy.Text.urlToDisplay url) ] ]
+
+                Nothing ->
+                    text ""
+            ]
 
 
 viewAddress : Maybe Data.PlaceCal.Partners.Address -> Html msg

--- a/tests/Page/PartnerTests.elm
+++ b/tests/Page/PartnerTests.elm
@@ -24,10 +24,11 @@ viewParamsWithPartner =
             , description = "Partner description"
             , summary = "Partner summary"
             , maybeUrl = Just "https://www.example.com"
-            , contactDetails =
-                { email = "partner@example.com"
-                , telephone = "0161 496 0000"
-                }
+            , maybeContactDetails =
+                Just
+                    { email = "partner@example.com"
+                    , telephone = "0161 496 0000"
+                    }
             , maybeAddress =
                 Just
                     { streetAddress = "1 The Street"
@@ -69,10 +70,23 @@ viewParamsWithPartner =
     }
 
 
-viewParamsWithoutMaybes =
+viewParamsWithoutUrlOrAddress =
     let
         setData oldData =
             { oldData | maybeUrl = Nothing, maybeAddress = Nothing }
+    in
+    { viewParamsWithPartner
+        | data =
+            { partner = setData viewParamsWithPartner.data.partner
+            , events = viewParamsWithPartner.data.events
+            }
+    }
+
+
+viewParamsWithoutContactDetailsOrUrl =
+    let
+        setData oldData =
+            { oldData | maybeUrl = Nothing, maybeContactDetails = Nothing }
     in
     { viewParamsWithPartner
         | data =
@@ -137,9 +151,14 @@ suite =
                         ]
         , test "Contains address empty text if not provided" <|
             \_ ->
-                viewBodyHtml eventsModel viewParamsWithoutMaybes
+                viewBodyHtml eventsModel viewParamsWithoutUrlOrAddress
                     |> Query.contains
                         [ Html.text (t PartnerAddressEmptyText) ]
+        , test "Contains contact empty text if no details or url" <|
+            \_ ->
+                viewBodyHtml eventsModel viewParamsWithoutContactDetailsOrUrl
+                    |> Query.contains
+                        [ Html.text (t PartnerContactsEmptyText) ]
         , test "Contact details contain url if provided" <|
             \_ ->
                 viewBodyHtml eventsModel viewParamsWithPartner
@@ -153,22 +172,6 @@ suite =
                                     [ Selector.text "www.example.com"
                                     ]
                                 , Selector.attribute (Html.Attributes.href "https://www.example.com")
-                                ]
-                            ]
-                        ]
-        , test "Can have contact details without url" <|
-            \_ ->
-                viewBodyHtml eventsModel viewParamsWithoutMaybes
-                    |> Query.has
-                        [ Selector.tag "address"
-                        , Selector.containing
-                            [ Selector.tag "p"
-                            , Selector.containing
-                                [ Selector.tag "a"
-                                , Selector.containing
-                                    [ Selector.text "partner@example.com"
-                                    ]
-                                , Selector.attribute (Html.Attributes.href "mailto:partner@example.com")
                                 ]
                             ]
                         ]

--- a/tests/TestFixtures.elm
+++ b/tests/TestFixtures.elm
@@ -27,8 +27,8 @@ partners =
                 , addressRegion = "London"
                 , postalCode = "SE1 1RB"
                 }
-      , contactDetails =
-            { email = "partner1@example.com", telephone = "020 7946 0100" }
+      , maybeContactDetails =
+            Just { email = "partner1@example.com", telephone = "020 7946 0100" }
       , areasServed = []
       , maybeGeo = Nothing
       , maybeLogo = Nothing
@@ -44,8 +44,8 @@ partners =
                 , addressRegion = "London"
                 , postalCode = "WC1N 3XX"
                 }
-      , contactDetails =
-            { email = "partner2@example.com", telephone = "020 7946 0200" }
+      , maybeContactDetails =
+            Just { email = "partner2@example.com", telephone = "020 7946 0200" }
       , areasServed =
             [ { name = "Central London", abbreviatedName = Just "Central Ldn" }
             ]
@@ -58,8 +58,8 @@ partners =
       , description = "Partner three intro"
       , maybeUrl = Nothing
       , maybeAddress = Nothing
-      , contactDetails =
-            { email = "partner3@example.com", telephone = "0121 496 0300" }
+      , maybeContactDetails =
+            Just { email = "partner3@example.com", telephone = "020 7946 0300" }
       , areasServed =
             [ { name = "Birmingham", abbreviatedName = Nothing }
             , { name = "London", abbreviatedName = Nothing }
@@ -78,8 +78,7 @@ partners =
                 , addressRegion = "London"
                 , postalCode = "N2 2AA"
                 }
-      , contactDetails =
-            { email = "partner4@example.com", telephone = "020 7946 0400" }
+      , maybeContactDetails = Nothing
       , areasServed = []
       , maybeGeo = Nothing
       , maybeLogo = Nothing


### PR DESCRIPTION
Fixes #400

## Description

- Covert `partner.contactDetails` to a `Maybe`
- Add empty text to Contact details section on Partner view
- Amend tests for new cases
