### PR TITLE
fix: Allow events up to June 2025. Allow null partner telephone or email

### DIFF
--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -133,7 +133,7 @@ allEventsQuery =
         [ ( "query"
             -- Note hardcoded to load events from 2022-09-01
           , Json.Encode.string """
-            query { eventsByFilter(tagId: 3, fromDate: "2023-06-15 00:00", toDate: "2024-06-15 00:00") {
+            query { eventsByFilter(tagId: 3, fromDate: "2024-01-01 00:00", toDate: "2025-06-15 00:00") {
               id
               name
               summary

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -148,8 +148,8 @@ geoDecoder =
 contactDecoder : OptimizedDecoder.Decoder Contact
 contactDecoder =
     OptimizedDecoder.succeed Contact
-        |> OptimizedDecoder.Pipeline.required "email" OptimizedDecoder.string
-        |> OptimizedDecoder.Pipeline.required "telephone" OptimizedDecoder.string
+        |> OptimizedDecoder.Pipeline.optional "email" OptimizedDecoder.string ""
+        |> OptimizedDecoder.Pipeline.optional "telephone" OptimizedDecoder.string ""
 
 
 addressDecoder : OptimizedDecoder.Decoder Address


### PR DESCRIPTION
Fixes #402 

## Description

- Allow partner contact to contain `null` for contact phone or email
- Import events Jan 2024 to June 2025
