### PR TITLE
feat: persist region filter in URL in and across pages

### DIFF
--- a/app/Shared.elm
+++ b/app/Shared.elm
@@ -103,7 +103,7 @@ filterFromPath maybePagePath =
 filterFromQueryParams : String -> String
 filterFromQueryParams queryParams =
     Pages.PageUrl.parseQueryParams queryParams
-        |> Dict.get "filter"
+        |> Dict.get "region"
         |> Maybe.withDefault []
         |> List.head
         |> Maybe.withDefault ""
@@ -205,7 +205,7 @@ regionFilterQuery model =
     in
     case selectedRegionName of
         Just regionName ->
-            "?filter=" ++ String.toLower regionName
+            "?region=" ++ String.toLower regionName
 
         Nothing ->
             ""

--- a/app/Shared.elm
+++ b/app/Shared.elm
@@ -1,8 +1,7 @@
-module Shared exposing (Data, Model, Msg, template)
+port module Shared exposing (Data, Model, Msg, template)
 
 import BackendTask exposing (BackendTask)
 import BackendTask.Time
-import Browser.Navigation
 import Data.PlaceCal.Articles
 import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
@@ -113,8 +112,51 @@ filterFromQueryParams queryParams =
 update : Msg -> Model -> ( Model, Effect Msg )
 update msg model =
     case msg of
-        OnPageChange _ ->
-            ( { model | showMobileMenu = False }, Effect.none )
+        OnPageChange pagePath ->
+            let
+                route =
+                    Route.segmentsToRoute pagePath.path
+
+                baseUpdate =
+                    ( { model | showMobileMenu = False }, Effect.none )
+            in
+            -- only update the region filter in URL if the route is Events, Index or Partners
+            case route of
+                Just Route.Events ->
+                    baseUpdate
+                        |> updateRegionFilter model.filterParam
+
+                Just Route.Index ->
+                    baseUpdate
+                        |> updateRegionFilter model.filterParam
+
+                Just Route.Partners ->
+                    baseUpdate
+                        |> updateRegionFilter model.filterParam
+
+                Just (Route.Events__Event_ _) ->
+                    baseUpdate
+
+                Just Route.News ->
+                    baseUpdate
+
+                Just (Route.News__NewsItem_ _) ->
+                    baseUpdate
+
+                Just (Route.Partners__Partner_ _) ->
+                    baseUpdate
+
+                Just Route.About ->
+                    baseUpdate
+
+                Just Route.JoinUs ->
+                    baseUpdate
+
+                Just Route.Privacy ->
+                    baseUpdate
+
+                Nothing ->
+                    baseUpdate
 
         -- Header
         ToggleMenu ->
@@ -123,15 +165,55 @@ update msg model =
         -- Shared
         SharedMsg _ ->
             ( model, Effect.none )
-        
+
         -- Update region filter
         SetRegion tagId ->
-            ( { model | filterParam = Just (tagId) }, Effect.none )
+            updateRegionFilter (Just tagId) ( model, Effect.none )
+
+        UrlChanged url ->
+            let
+                queryParamsFromUrl =
+                    case String.split "?" url of
+                        [ _, queryRegion ] ->
+                            queryRegion
+
+                        _ ->
+                            ""
+
+                maybeRegionId =
+                    Data.PlaceCal.Partners.filterFromQueryString (filterFromQueryParams queryParamsFromUrl)
+            in
+            ( { model | filterParam = maybeRegionId }, Effect.none )
+
+
+updateRegionFilter : Maybe Int -> ( Model, Effect Msg ) -> ( Model, Effect Msg )
+updateRegionFilter maybeRegionId ( model, effect ) =
+    let
+        newQuery =
+            regionFilterQuery { model | filterParam = maybeRegionId }
+    in
+    ( model, Effect.batch [ effect, Effect.fromCmd <| requestUrlChange newQuery ] )
+
+
+regionFilterQuery : Model -> String
+regionFilterQuery model =
+    let
+        selectedRegionName =
+            model.filterParam
+                |> Maybe.andThen Data.PlaceCal.Partners.getTagInfoById
+                |> Maybe.map .name
+    in
+    case selectedRegionName of
+        Just regionName ->
+            "?filter=" ++ String.toLower regionName
+
+        Nothing ->
+            ""
 
 
 subscriptions : UrlPath -> Model -> Sub Msg
 subscriptions _ _ =
-    Sub.none
+    onUrlChange UrlChanged
 
 
 data : BackendTask FatalError Data
@@ -177,3 +259,16 @@ view sharedData page model toMsg pageView =
         ]
     , title = pageView.title
     }
+
+
+
+-------------
+-- Ports
+-------------
+{- elm-pages does not offer a way to listen to URL changes yet, so we use ports as a workaround for now - -}
+
+
+port onUrlChange : (String -> msg) -> Sub msg
+
+
+port requestUrlChange : String -> Cmd msg

--- a/index.ts
+++ b/index.ts
@@ -3,9 +3,34 @@ type ElmPagesInit = {
   flags: unknown;
 };
 
+interface ElmApp {
+  ports: {
+    requestUrlChange: {
+      subscribe: (callback: (newQuery: string) => void) => void;
+    };
+    onUrlChange: {
+      send: (newUrl: string) => void;
+    };
+  };
+}
+
 const config: ElmPagesInit = {
   load: async function (elmLoaded) {
-    await elmLoaded;
+    const app = await elmLoaded as ElmApp;
+    if (app.ports.requestUrlChange) {
+      app.ports.requestUrlChange.subscribe((newQuery: string) => {
+        // Build the new href with the new query
+        const newHref = window.location.pathname + newQuery;
+
+        // Push it into history
+        window.history.replaceState({}, "", newHref);
+
+        // Notify Elm of the new URL
+        if (app.ports.onUrlChange) {
+          app.ports.onUrlChange.send(window.location.href);
+        }
+      });
+    }
   },
   flags: function () {
     return "You can decode this in Shared.elm using Json.Decode.string!";

--- a/src/Data/PlaceCal/Partners.elm
+++ b/src/Data/PlaceCal/Partners.elm
@@ -1,4 +1,4 @@
-module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, filterFromQueryString, partnerFromSlug, partnerNamesFromIds, partnersData, partnersFromRegionId, partnershipTagIdList, partnershipTagList)
+module Data.PlaceCal.Partners exposing (Address, Contact, Partner, ServiceArea, filterFromQueryString, partnerFromSlug, partnerNamesFromIds, partnersData, partnersFromRegionId, partnershipTagIdList, partnershipTagList, PartnershipTag, getTagInfoById)
 
 import BackendTask
 import BackendTask.Custom
@@ -122,8 +122,7 @@ partnershipTagName tagInfo =
 filterFromQueryString : String -> Maybe Int
 filterFromQueryString queryString =
     partnershipTagList
-        |> List.map (\tagInfo -> { tagInfo | name = String.toLower tagInfo.name })
-        |> List.filter (\tagInfo -> tagInfo.name == String.toLower queryString)
+        |> List.filter (\tagInfo -> String.toLower tagInfo.name == String.toLower queryString)
         |> Maybe.withDefault List.head Nothing
         |> maybeMatchTagId
 
@@ -136,6 +135,12 @@ maybeMatchTagId maybeTagInfo =
 
         Nothing ->
             Nothing
+
+getTagInfoById : Int -> Maybe PartnershipTag
+getTagInfoById tagId =
+    partnershipTagList
+        |> List.filter (\tagInfo -> tagInfo.id == tagId)
+        |> List.head
 
 
 partnersData : BackendTask.BackendTask { fatal : FatalError.FatalError, recoverable : BackendTask.Custom.Error } AllPartnersResponse

--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -15,6 +15,7 @@ type Msg
       -- Shared
     | SharedMsg SharedMsg
     | SetRegion Int
+    | UrlChanged String
 
 
 type SharedMsg

--- a/tests/Page/EventsTests.elm
+++ b/tests/Page/EventsTests.elm
@@ -1,0 +1,56 @@
+module Page.EventsTests exposing (..)
+
+import Copy.Keys exposing (Key(..))
+import Expect
+import Messages exposing (Msg(..))
+import Test exposing (Test, describe, test)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+import TestFixtures
+import TestUtils exposing (queryFromStyled)
+import Theme.Page.Events as EventsPage
+import Theme.Paginator exposing (Filter(..))
+import Theme.RegionSelector exposing (Msg(..))
+import Time
+
+
+viewEventsPageHtml filter =
+    queryFromStyled
+        (EventsPage.viewEvents TestFixtures.events { filterByDate = Past, filterByRegion = filter, nowTime = Time.millisToPosix 1645466500000 })
+
+
+suite : Test
+suite =
+    describe "Test event filter by region"
+        [ test "Should trigger ClickedSelector Msg" <|
+            \_ ->
+                viewEventsPageHtml 0
+                    |> Query.findAll [ Selector.tag "button", Selector.containing [ Selector.text "London" ] ]
+                    |> Query.first
+                    |> Event.simulate Event.click
+                    |> Event.expect (EventsPage.RegionSelectorMsg (ClickedSelector 3))
+        , test "Should list all events 'everywhere' is selected " <|
+            \_ ->
+                viewEventsPageHtml 0
+                    |> Query.findAll [ Selector.tag "li", Selector.containing [ Selector.tag "article" ] ]
+                    |> Query.count (Expect.equal 2)
+        , test "Should list only events in London when 'London' is selected" <|
+            \_ ->
+                viewEventsPageHtml 3
+                    |> Query.findAll [ Selector.tag "li", Selector.containing [ Selector.tag "article" ] ]
+                    |> Expect.all
+                        [ Query.count (Expect.equal 1)
+                        , Query.first >> Query.hasNot [ Selector.tag "h4", Selector.containing [ Selector.text "Event 1 name" ] ]
+                        , Query.first >> Query.has [ Selector.tag "h4", Selector.containing [ Selector.text "Event 2 name" ] ]
+                        ]
+        , test "Should list only events in Manchester when 'Manchester' is selected" <|
+            \_ ->
+                viewEventsPageHtml 30
+                    |> Query.findAll [ Selector.tag "li", Selector.containing [ Selector.tag "article" ] ]
+                    |> Expect.all
+                        [ Query.count (Expect.equal 1)
+                        , Query.first >> Query.hasNot [ Selector.tag "h4", Selector.containing [ Selector.text "Event 2 name" ] ]
+                        , Query.first >> Query.has [ Selector.tag "h4", Selector.containing [ Selector.text "Event 1 name" ] ]
+                        ]
+        ]

--- a/tests/TestFixtures.elm
+++ b/tests/TestFixtures.elm
@@ -116,7 +116,7 @@ partners =
 events : List Event
 events =
     [ { id = "1"
-      , partnershipTagId = 0
+      , partnershipTagId = 30
       , name = "Event 1 name"
       , summary = "A summary of the first event"
       , description = "Fusce at sodales lacus. Morbi scelerisque lacus leo, ac mattis urna ultrices et. Proin ac eros faucibus, consequat ante vel, vulputate lectus. Nunc dictum pharetra ex, eget vestibulum lacus. Maecenas molestie felis in turpis eleifend, nec accumsan massa sodales. Nulla facilisi. Vivamus id rhoncus nulla. Nunc ultricies lectus et dui tempor sodales. Curabitur interdum lectus ultricies est ultricies, at faucibus nisi semper. Praesent iaculis ornare orci. Sed vel metus pharetra, efficitur leo a, porttitor magna. Curabitur sit amet mollis ex."
@@ -130,7 +130,7 @@ events =
       , partner = { id = "1", name = Just "Partner one", maybeUrl = Nothing, maybeContactDetails = Nothing }
       }
     , { id = "2"
-      , partnershipTagId = 1
+      , partnershipTagId = 3
       , name = "Event 2 name"
       , summary = "A summary of the second event"
       , description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur ut risus placerat, suscipit lacus quis, pretium nisl. Fusce enim erat, fringilla ac auctor scelerisque, scelerisque non ipsum. Vivamus non elit id orci aliquam lobortis at sit amet ligula. Aenean vel massa pellentesque, viverra turpis et, commodo ipsum. Vivamus nunc elit, elementum et ipsum id, rutrum commodo sapien. Integer eget mi eget lacus sagittis molestie feugiat at lacus. Cras ultrices molestie blandit. Suspendisse gravida tortor non risus vestibulum laoreet. Nam nec quam id nisi suscipit consectetur. Aliquam venenatis tortor elit, id suscipit augue feugiat ac."


### PR DESCRIPTION
Closes #466.

This PR:

- Add filter param to URL when one of the regions is selected in Events, Partners, or Index page;
- Persist the region in the URL when switching from one of these pages to the others.

I’m not entirely sure this is the best way to implement this feature, but I couldn’t find any other approach. In Elm Pages, there doesn’t appear to be a straightforward way to manage or [track URL changes](https://github.com/dillonkearns/elm-pages/issues/509) directly (using anchor elements with preventDefault to change the URL resulted in strange scrolling behavior).

Since this is my first time using Elm Pages, I may be missing a simpler approach. I’d be happy to hear any suggestions on how to do this in a cleaner way, ideally without using JavaScript/ports and direct history manipulation.

Regarding testing, ideally we should test the behavior of storing and retrieving the URL filter, but I haven’t had much success with that either. It seems to me that this is a case where it would be much simpler to test the entire behavior using a framework like the one suggested by @kimadactyl in #492