### PR TITLE
Add publisherUrl to singleEventQuery

### DIFF
--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -241,6 +241,7 @@ singleEventQuery eventId =
                     description
                     startDate
                     endDate
+                    publisherUrl
                     address {
                       streetAddress
                       postalCode


### PR DESCRIPTION
Fixes #518

## Description

- The `publisherUrl` field was missing from the GraphQL query for a single event.
- This fix ensures that a link to the `publisherUrl` is rendered on the Event page for events with a valid URL:

![Screenshot 2025-05-14 at 08 38 55](https://github.com/user-attachments/assets/d67617ec-3e0e-4f6d-83c8-c8fa9f8dc757)