### PR TITLE
WIP: Use timezone for date/time conversion

### DIFF
--- a/app/Route/Events.elm
+++ b/app/Route/Events.elm
@@ -25,7 +25,7 @@ import Theme.Page.Events
 import Theme.PageTemplate
 import Theme.Paginator
 import Theme.RegionSelector
-import Time
+import Time exposing (utc)
 import UrlPath
 import View exposing (View)
 
@@ -34,6 +34,7 @@ type alias Model =
     { filterByDate : Theme.Paginator.Filter
     , filterByRegion : Int
     , nowTime : Time.Posix
+    , timezone : Time.Zone
     , viewportWidth : Float
     }
 
@@ -54,11 +55,13 @@ init app shared =
     ( { filterByDate = Theme.Paginator.None
       , filterByRegion = Maybe.withDefault 0 shared.filterParam
       , nowTime = Time.millisToPosix 0
+      , timezone = utc
       , viewportWidth = 320
       }
     , Effect.batch
         [ Task.perform Theme.Paginator.GetTime Time.now |> Cmd.map Theme.Page.Events.fromPaginatorMsg |> Effect.fromCmd
         , Task.perform Theme.Paginator.GotViewport Browser.Dom.getViewport |> Cmd.map Theme.Page.Events.fromPaginatorMsg |> Effect.fromCmd
+        , Task.perform Theme.Page.Events.GetTimeZone Time.here |> Effect.fromCmd
         ]
     )
 
@@ -143,6 +146,9 @@ update app _ msg model =
 
         Theme.Page.Events.ClickedGoToNextEvent nextEventTime ->
             ( { model | filterByDate = Theme.Paginator.Day nextEventTime }, Effect.none, Nothing )
+
+        Theme.Page.Events.GetTimeZone zone ->
+            ( { model | timezone = zone }, Effect.none, Nothing )
 
 
 subscriptions : RouteParams -> UrlPath.UrlPath -> Shared.Model -> Model -> Sub Msg

--- a/app/Route/Events/Event_.elm
+++ b/app/Route/Events/Event_.elm
@@ -19,6 +19,7 @@ import RouteBuilder
 import Shared
 import Theme.Page.Event
 import Theme.PageTemplate
+import Time exposing (utc)
 import View
 
 
@@ -89,7 +90,7 @@ eventMetaTagTitle event =
             TransDate.humanDayDateMonthFromPosix event.startDatetime
 
         ( eventHourStart, eventHourEnd ) =
-            ( TransDate.humanTimeFromPosix event.startDatetime, TransDate.humanTimeFromPosix event.endDatetime )
+            ( TransDate.humanTimeFromPosix event.startDatetime utc, TransDate.humanTimeFromPosix event.endDatetime utc )
 
         partnerName =
             event.partner.name |> Maybe.withDefault ""
@@ -101,7 +102,7 @@ view :
     RouteBuilder.App Data ActionData RouteParams
     -> Shared.Model
     -> View.View (PagesMsg.PagesMsg Msg)
-view app _ =
+view app model =
     let
         event : Data.PlaceCal.Events.Event
         event =
@@ -115,7 +116,7 @@ view app _ =
             , title = t EventsTitle
             , bigText = { text = event.name, node = "h3" }
             , smallText = Nothing
-            , innerContent = Just (Theme.Page.Event.viewEventInfo event)
+            , innerContent = Just (Theme.Page.Event.viewEventInfo event model.timezone)
             , outerContent = Just (Theme.Page.Event.viewButtons event)
             }
         ]

--- a/app/Route/Index.elm
+++ b/app/Route/Index.elm
@@ -124,7 +124,7 @@ view :
     -> Shared.Model
     -> Model
     -> View.View (PagesMsg.PagesMsg Msg)
-view app _ model =
+view app shared model =
     { title = t SiteTitle
     , body =
         let
@@ -136,6 +136,7 @@ view app _ model =
                 , partners = sharedData.partners
                 , articles = sharedData.articles
                 , time = sharedData.time
+                , timezone = shared.timezone
                 }
         in
         [ Theme.Page.Index.view sharedDataWithEvents model

--- a/app/Route/Partners/Partner_.elm
+++ b/app/Route/Partners/Partner_.elm
@@ -37,6 +37,7 @@ type alias Model =
     , nowTime : Time.Posix
     , viewportWidth : Float
     , urlFragment : Maybe String
+    , timezone : Time.Zone
     }
 
 
@@ -81,6 +82,7 @@ init app _ =
             , Task.perform GotViewport Browser.Dom.getViewport
                 |> Cmd.map Theme.Page.Events.fromPaginatorMsg
                 |> Effect.fromCmd
+            , Task.perform Theme.Page.Events.GetTimeZone Time.here |> Effect.fromCmd
             ]
     in
     ( { filterByDate = Theme.Paginator.None
@@ -88,6 +90,7 @@ init app _ =
       , nowTime = Time.millisToPosix 0
       , viewportWidth = 320
       , urlFragment = urlFragment
+      , timezone = Time.utc
       }
     , Effect.batch
         (case urlFragment of
@@ -174,6 +177,9 @@ update app _ msg model =
 
         Theme.Page.Events.ClickedGoToNextEvent nextEventTime ->
             ( { model | filterByDate = Theme.Paginator.Day nextEventTime }, Effect.none )
+
+        Theme.Page.Events.GetTimeZone zone ->
+            ( { model | timezone = zone }, Effect.none )
 
 
 subscriptions : RouteParams -> UrlPath.UrlPath -> Shared.Model -> Model -> Sub Msg

--- a/app/Shared.elm
+++ b/app/Shared.elm
@@ -3,7 +3,6 @@ port module Shared exposing (Data, Model, Msg, template)
 import BackendTask exposing (BackendTask)
 import BackendTask.Time
 import Data.PlaceCal.Articles
-import Data.PlaceCal.Events
 import Data.PlaceCal.Partners
 import Dict
 import Effect exposing (Effect)
@@ -15,6 +14,7 @@ import Pages.Flags
 import Pages.PageUrl exposing (PageUrl)
 import Route exposing (Route)
 import SharedTemplate exposing (SharedTemplate)
+import Task
 import Theme.Global
 import Theme.PageFooter exposing (viewPageFooter)
 import Theme.PageHeader exposing (viewPageHeader)
@@ -60,6 +60,7 @@ type alias Msg =
 type alias Model =
     { showMobileMenu : Bool
     , filterParam : Maybe Int
+    , timezone : Time.Zone
     }
 
 
@@ -79,8 +80,9 @@ init :
 init flags maybePagePath =
     ( { showMobileMenu = False
       , filterParam = filterFromPath maybePagePath
+      , timezone = Time.utc
       }
-    , Effect.none
+    , Task.perform Messages.GetTimeZone Time.here |> Effect.fromCmd
     )
 
 
@@ -183,6 +185,9 @@ update msg model =
                     Data.PlaceCal.Partners.filterFromQueryString (filterFromQueryParams queryParamsFromUrl)
             in
             ( { model | filterParam = maybeRegionId }, Effect.none )
+
+        GetTimeZone zone ->
+            ( { model | timezone = zone }, Effect.none )
 
 
 updateRegionFilter : Maybe Int -> ( Model, Effect Msg ) -> ( Model, Effect Msg )

--- a/src/Helpers/TransDate.elm
+++ b/src/Helpers/TransDate.elm
@@ -141,8 +141,8 @@ humanShortMonthFromPosix timestamp =
             timestamp
 
 
-humanTimeFromPosix : Time.Posix -> String
-humanTimeFromPosix timestamp =
+humanTimeFromPosix : Time.Posix -> Time.Zone -> String
+humanTimeFromPosix timestamp timezone =
     if timestamp == defaultPosix then
         "Invalid time"
 
@@ -153,7 +153,7 @@ humanTimeFromPosix timestamp =
             , DateFormat.minuteFixed
             , DateFormat.amPmLowercase
             ]
-            convertedIsoDateZone
+            timezone
             timestamp
 
 

--- a/src/Messages.elm
+++ b/src/Messages.elm
@@ -1,5 +1,6 @@
 module Messages exposing (Msg(..), SharedMsg(..))
 
+import Time
 import UrlPath exposing (UrlPath)
 
 
@@ -15,6 +16,7 @@ type Msg
     | SharedMsg SharedMsg
     | SetRegion Int
     | UrlChanged String
+    | GetTimeZone Time.Zone
 
 
 type SharedMsg

--- a/src/Theme/Page/Event.elm
+++ b/src/Theme/Page/Event.elm
@@ -10,12 +10,13 @@ import Html.Styled exposing (Html, a, div, h4, hr, p, section, text, time)
 import Html.Styled.Attributes exposing (css, href, target)
 import Theme.Global exposing (linkStyle, normalFirstParagraphStyle, pink, smallInlineTitleStyle, withMediaMediumDesktopUp, withMediaTabletLandscapeUp, withMediaTabletPortraitUp)
 import Theme.TransMarkdown
+import Time
 
 
-viewEventInfo : Data.PlaceCal.Events.Event -> Html msg
-viewEventInfo event =
+viewEventInfo : Data.PlaceCal.Events.Event -> Time.Zone -> Html msg
+viewEventInfo event timezone =
     div []
-        [ viewDateTimeSection event
+        [ viewDateTimeSection event timezone
         , hr [ css [ Theme.Global.hrStyle ] ] []
         , viewInfoSection event
         , hr [ css [ Theme.Global.hrStyle, marginTop (rem 2.5) ] ] []
@@ -36,11 +37,11 @@ viewEventInfo event =
         ]
 
 
-viewDateTimeSection : Data.PlaceCal.Events.Event -> Html msg
-viewDateTimeSection event =
+viewDateTimeSection : Data.PlaceCal.Events.Event -> Time.Zone -> Html msg
+viewDateTimeSection event timezone =
     section [ css [ dateAndTimeStyle ] ]
         [ p [ css [ dateStyle ] ] [ time [] [ text (Helpers.TransDate.humanDateFromPosix event.startDatetime) ] ]
-        , p [ css [ timeStyle ] ] [ time [] [ text (Helpers.TransDate.humanTimeFromPosix event.startDatetime), text " - ", text (Helpers.TransDate.humanTimeFromPosix event.endDatetime) ] ]
+        , p [ css [ timeStyle ] ] [ time [] [ text (Helpers.TransDate.humanTimeFromPosix event.startDatetime timezone), text " - ", text (Helpers.TransDate.humanTimeFromPosix event.endDatetime timezone) ] ]
         ]
 
 

--- a/src/Theme/Page/Events.elm
+++ b/src/Theme/Page/Events.elm
@@ -22,6 +22,7 @@ type Msg
     = PaginatorMsg Theme.Paginator.Msg
     | RegionSelectorMsg Theme.RegionSelector.Msg
     | ClickedGoToNextEvent Time.Posix
+    | GetTimeZone Time.Zone
 
 
 fromPaginatorMsg : Theme.Paginator.Msg -> Msg
@@ -41,6 +42,7 @@ viewEvents :
             | filterByDate : Theme.Paginator.Filter
             , filterByRegion : Int
             , nowTime : Time.Posix
+            , timezone : Time.Zone
         }
     -> Html Msg
 viewEvents eventsList model =
@@ -60,6 +62,7 @@ viewEventsList :
         | filterByDate : Theme.Paginator.Filter
         , filterByRegion : Int
         , nowTime : Time.Posix
+        , timezone : Time.Zone
     }
     -> List Data.PlaceCal.Events.Event
     -> Maybe Int
@@ -90,7 +93,7 @@ viewEventsList localModel eventsList maybeListLength =
     div []
         [ if List.length filteredEvents > 0 then
             ul [ css [ eventsListStyle ] ]
-                (List.map (\event -> viewEvent event) filteredEvents)
+                (List.map (\event -> viewEvent event localModel.timezone) filteredEvents)
                 |> Html.Styled.map fromPaginatorMsg
 
           else
@@ -127,8 +130,8 @@ viewEmptyEventText filterBy =
         ]
 
 
-viewEvent : Data.PlaceCal.Events.Event -> Html msg
-viewEvent event =
+viewEvent : Data.PlaceCal.Events.Event -> Time.Zone -> Html msg
+viewEvent event timezone =
     li [ css [ eventsListItemStyle ] ]
         [ a [ css [ eventLinkStyle ], href (TransRoutes.toAbsoluteUrl (Event event.id)) ]
             [ article [ css [ eventStyle ] ]
@@ -136,9 +139,9 @@ viewEvent event =
                     [ h4 [ css [ eventTitleStyle ] ] [ text event.name ]
                     , div []
                         [ p [ css [ eventParagraphStyle ] ]
-                            [ time [] [ text (TransDate.humanTimeFromPosix event.startDatetime) ]
+                            [ time [] [ text (TransDate.humanTimeFromPosix event.startDatetime timezone) ]
                             , span [] [ text " — " ]
-                            , time [] [ text (TransDate.humanTimeFromPosix event.endDatetime) ]
+                            , time [] [ text (TransDate.humanTimeFromPosix event.endDatetime timezone) ]
                             ]
                         , case event.location of
                             Just aLocation ->

--- a/src/Theme/Page/Index.elm
+++ b/src/Theme/Page/Index.elm
@@ -22,6 +22,7 @@ view :
     , partners : List Data.PlaceCal.Partners.Partner
     , articles : List Data.PlaceCal.Articles.Article
     , time : Time.Posix
+    , timezone : Time.Zone
     }
     ->
         { localModel
@@ -32,7 +33,7 @@ view :
 view sharedData localModel =
     div [ css [ pageWrapperStyle ] ]
         [ viewIntro (t IndexIntroTitle) (t IndexIntroMessage) (t IndexIntroButtonText)
-        , viewFeatured localModel.nowTime (Data.PlaceCal.Events.eventsWithPartners sharedData.events sharedData.partners) localModel.filterByRegion
+        , viewFeatured localModel.nowTime sharedData.timezone (Data.PlaceCal.Events.eventsWithPartners sharedData.events sharedData.partners) localModel.filterByRegion
         , viewLatestNews (List.head sharedData.articles) (t IndexNewsHeader) (t IndexNewsButtonText)
         ]
 
@@ -60,8 +61,8 @@ viewIntro introTitle introMsg eventButtonText =
         ]
 
 
-viewFeatured : Time.Posix -> List Data.PlaceCal.Events.Event -> Int -> Html Msg
-viewFeatured fromTime eventList regionId =
+viewFeatured : Time.Posix -> Time.Zone -> List Data.PlaceCal.Events.Event -> Int -> Html Msg
+viewFeatured fromTime timezone eventList regionId =
     section [ css [ sectionStyle, Theme.Global.darkBlueBackgroundStyle, eventsSectionStyle ] ]
         [ h2 [ css [ Theme.Global.smallFloatingTitleStyle ] ] [ text (t IndexFeaturedHeader) ]
         , if List.length Data.PlaceCal.Partners.partnershipTagList > 1 then
@@ -69,7 +70,7 @@ viewFeatured fromTime eventList regionId =
 
           else
             text ""
-        , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime } eventList (Just 8)
+        , Theme.Page.Events.viewEventsList { filterByDate = Theme.Paginator.Future, filterByRegion = regionId, nowTime = fromTime, timezone = timezone } eventList (Just 8)
         , viewAllEventsButton
         ]
 

--- a/src/Theme/Page/Partner.elm
+++ b/src/Theme/Page/Partner.elm
@@ -19,6 +19,7 @@ viewInfo :
         | filterByDate : Theme.Paginator.Filter
         , filterByRegion : Int
         , nowTime : Time.Posix
+        , timezone : Time.Zone
     }
     ->
         { partner : Data.PlaceCal.Partners.Partner
@@ -65,6 +66,7 @@ viewPartnerEvents :
             | filterByDate : Theme.Paginator.Filter
             , filterByRegion : Int
             , nowTime : Time.Posix
+            , timezone : Time.Zone
         }
     -> Data.PlaceCal.Partners.Partner
     -> Html Theme.Page.Events.Msg

--- a/tests/Page/EventsTests.elm
+++ b/tests/Page/EventsTests.elm
@@ -17,7 +17,7 @@ import Time
 
 viewEventsPageHtml filter =
     queryFromStyled
-        (EventsPage.viewEvents TestFixtures.events { filterByDate = Past, filterByRegion = filter, nowTime = Time.millisToPosix 1645466500000 })
+        (EventsPage.viewEvents TestFixtures.events { filterByDate = Past, filterByRegion = filter, nowTime = Time.millisToPosix 1645466500000, timezone = Time.utc })
 
 
 suite : Test

--- a/tests/TestFixtures.elm
+++ b/tests/TestFixtures.elm
@@ -21,6 +21,7 @@ sharedModelInit : Shared.Model
 sharedModelInit =
     { showMobileMenu = False
     , filterParam = Nothing
+    , timezone = Time.utc
     }
 
 


### PR DESCRIPTION
Fixes #448 

## Description

- It was observed that event times were incorrect during BST (GMT + 01:00).

## Why was this happening?

- Event times in GraphQL are in ISO 8601 format - for example: `"2025-05-26T20:00:00+01:00"`.
- We use `Iso8601.toTime` to convert ISO 8601 date strings into Posix times.
- `Iso8601.toTime` normalises ISO 8601 date strings with an offset - in this case, converting `20:00:00` to `19:00:00`.
- We then used `DateFormat.format` to convert the Posix time into a human-readable string.
- `DateFormat.format` expects a timezone - we were using `utc` rather than the actual timezone, which meant that we were presenting the normalised UTC time.

Now, the app gets the user's timezone and passes it into `DateFormat.format`, so the correct time is presented.

Before:

![Screenshot 2025-05-26 at 16 48 52](https://github.com/user-attachments/assets/123bf541-cf72-4a38-bbf8-d1690d96e192)
![Screenshot 2025-05-26 at 16 50 21](https://github.com/user-attachments/assets/3e0e97c2-3b03-4838-b158-6c10c9d7e01d)

After:

![Screenshot 2025-05-26 at 16 49 12](https://github.com/user-attachments/assets/36593a10-a661-437a-8559-f492cc87ac4c)
![Screenshot 2025-05-26 at 16 50 56](https://github.com/user-attachments/assets/8a730614-8507-4029-85da-98274ac276f6)

Note: This is a WIP because I've only applied the change to time, not to days/months/years as well.