### PR TITLE
Use rolling date window based on build time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ PLACECAL_API=https://placecal.org/api/v1/graphql
 # comma seperated list of id|name for partnerships to include
 PARTNERSHIP_TAG_LIST=3|London,30|Manchester
 JOIN_US_FUNCTION_URL=https://formspree.io/f/xeqdljwl
+
+# Date range for events query (auto-generated at build time in CI)
+# For local dev, set manually or copy from a recent build
+FROM_DATE=2025-01-01 00:00
+TO_DATE=2025-07-01 00:00

--- a/elm-constants.json
+++ b/elm-constants.json
@@ -1,10 +1,12 @@
 {
-    "path": "./src",
-    "moduleName": "Constants",
-    "values": [
-        "CANONICAL_URL",
-        "PLACECAL_API",
-        "JOIN_US_FUNCTION_URL",
-        "PARTNERSHIP_TAG_LIST"
-    ]
-  }
+  "path": "./src",
+  "moduleName": "Constants",
+  "values": [
+    "CANONICAL_URL",
+    "PLACECAL_API",
+    "JOIN_US_FUNCTION_URL",
+    "PARTNERSHIP_TAG_LIST",
+    "FROM_DATE",
+    "TO_DATE"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "postinstall": "elm-tooling install",
     "start": "elm-constants && elm-pages dev --port 3030",
-    "build": "elm-constants && elm-pages build",
+    "build": "FROM_DATE=\"$(date -u -d '-1 month' '+%Y-%m-%d 00:00')\" TO_DATE=\"$(date -u -d '+6 months' '+%Y-%m-%d 00:00')\" elm-constants && elm-pages build",
     "format": "elm-format src tests",
     "review": "elm-review src app",
     "review-fix": "elm-review --fix src app",

--- a/src/Data/PlaceCal/Events.elm
+++ b/src/Data/PlaceCal/Events.elm
@@ -2,6 +2,7 @@ module Data.PlaceCal.Events exposing (Event, EventLocation, EventPartner, EventP
 
 import BackendTask
 import BackendTask.Custom
+import Constants
 import Data.PlaceCal.Api
 import Data.PlaceCal.Partners
 import FatalError
@@ -205,13 +206,14 @@ allEventsQuery : String -> Json.Encode.Value
 allEventsQuery partnershipTag =
     Json.Encode.object
         [ ( "query"
-            -- Note: these dates are hardcoded, but should be made variable
-            -- https://github.com/geeksforsocialchange/the-trans-dimension/issues/523
           , Json.Encode.string
                 ("query { eventsByFilter(tagId: "
                     ++ partnershipTag
-                    ++ """
-            , fromDate: "2025-09-01 00:00", toDate: "2026-04-01 00:00") {
+                    ++ ", fromDate: \""
+                    ++ Constants.fromDate
+                    ++ "\", toDate: \""
+                    ++ Constants.toDate
+                    ++ """") {
               id
               name
               summary


### PR DESCRIPTION
Fixes #523

## Changes
- Build script calculates FROM_DATE (-1 month) and TO_DATE (+6 months) at build time using GNU date
- Events.elm uses Constants instead of hardcoded dates
- Dates refresh automatically with each hourly rebuild on Cloudflare Pages

## Notes
- GNU date syntax works on Linux (Cloudflare Pages build environment)
- For local macOS dev, set FROM_DATE and TO_DATE manually in .env file