### PR TITLE
Filter for articles belonging to partnership tags

### DIFF
--- a/src/Data/PlaceCal/Articles.elm
+++ b/src/Data/PlaceCal/Articles.elm
@@ -42,24 +42,41 @@ emptyArticle =
 
 articlesData : BackendTask.BackendTask { fatal : FatalError.FatalError, recoverable : BackendTask.Custom.Error } AllArticlesResponse
 articlesData =
-    Data.PlaceCal.Api.fetchAndCachePlaceCalData "articles"
-        allArticlesQuery
-        articlesDecoder
+    BackendTask.combine
+        (List.map
+            (\partnershipTagInt ->
+                Data.PlaceCal.Api.fetchAndCachePlaceCalData
+                    ("articles-" ++ String.fromInt partnershipTagInt)
+                    (allArticlesQuery (String.fromInt partnershipTagInt))
+                    articlesDecoder
+            )
+            Data.PlaceCal.Partners.partnershipTagIdList
+        )
+        |> BackendTask.map (List.map .allArticles)
+        |> BackendTask.map List.concat
+        |> BackendTask.map sortArticlesByDate
+        |> BackendTask.map (\articles -> { allArticles = articles })
 
 
-allArticlesQuery : Json.Encode.Value
-allArticlesQuery =
+allArticlesQuery : String -> Json.Encode.Value
+allArticlesQuery partnershipTag =
     Json.Encode.object
         [ ( "query"
-          , Json.Encode.string """
-            query { articleConnection { edges {
-                node {
-                  articleBody
-                  datePublished
-                  headline
-                  providers { id }
-                  image
-            } } } }
+          , Json.Encode.string <|
+                """
+            query {
+                articlesByTag(tagId: """
+                    ++ partnershipTag
+                    ++ """) {
+                headline
+                articleBody
+                datePublished
+                providers {
+                    id
+                }
+                image
+                }
+            }
             """
           )
         ]
@@ -68,25 +85,33 @@ allArticlesQuery =
 articlesDecoder : Json.Decode.Decoder AllArticlesResponse
 articlesDecoder =
     Json.Decode.succeed AllArticlesResponse
-        |> Json.Decode.Pipeline.requiredAt [ "data", "articleConnection", "edges" ] (Json.Decode.list decode)
+        |> Json.Decode.Pipeline.requiredAt [ "data", "articlesByTag" ] (Json.Decode.list decode)
 
 
 decode : Json.Decode.Decoder Article
 decode =
     (Json.Decode.succeed Article
-        |> Json.Decode.Pipeline.requiredAt [ "node", "headline" ]
+        |> Json.Decode.Pipeline.required "headline"
             Json.Decode.string
-        |> Json.Decode.Pipeline.requiredAt [ "node", "articleBody" ]
+        |> Json.Decode.Pipeline.required "articleBody"
             Json.Decode.string
-        |> Json.Decode.Pipeline.requiredAt [ "node", "datePublished" ]
+        |> Json.Decode.Pipeline.required "datePublished"
             Helpers.TransDate.isoDateStringDecoder
-        |> Json.Decode.Pipeline.requiredAt [ "node", "providers" ]
+        |> Json.Decode.Pipeline.required "providers"
             (Json.Decode.list partnerIdDecoder)
-        |> Json.Decode.Pipeline.optionalAt [ "node", "image" ]
+        |> Json.Decode.Pipeline.optional "image"
             Json.Decode.string
             ""
     )
         |> Json.Decode.andThen (\article -> addStockImage article)
+
+
+sortArticlesByDate : List Article -> List Article
+sortArticlesByDate articles =
+    List.reverse <|
+        List.sortBy
+            (\article -> Time.posixToMillis article.publishedDatetime)
+            articles
 
 
 partnerIdDecoder : Json.Decode.Decoder String


### PR DESCRIPTION
## Description

The query for news articles currently fetches _all_ articles - this change ensures only articles belonging to configured partnerships will be listed. This will ensure articles published on other PlaceCals are not listed on the site.
