### PR TITLE
Move build to GitHub Actions with dependency caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,45 @@
 on:
+  push:
+    branches: [main]
   schedule:
     - cron: "0 * * * *"
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - run:
-          curl -X POST "https://api.cloudflare.com/client/v4/pages/webhooks/deploy_hooks/fe5b4ebb-7029-4c5a-8cd7-4b933dd7bdc0"
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Cache elm-stuff
+        uses: actions/cache@v4
+        with:
+          path: elm-stuff
+          key: elm-stuff-${{ hashFiles('elm.json', 'elm-tooling.json') }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          CANONICAL_URL: https://transdimension.uk/
+          PLACECAL_API: https://placecal.org/api/v1/graphql
+          PARTNERSHIP_TAG_LIST: "3|London,30|Manchester"
+          JOIN_US_FUNCTION_URL: https://formspree.io/f/xeqdljwl
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}


### PR DESCRIPTION
## Summary
Replaces the Cloudflare Pages webhook trigger with a full build-and-deploy pipeline in GitHub Actions. This enables caching of dependencies between builds.

- **node_modules** cached (keyed on `package-lock.json`) — avoids re-extracting ~400 npm packages
- **elm-stuff** cached (keyed on `elm.json` + `elm-tooling.json`) — avoids re-downloading Elm compiler, elm-format, elm-test-rs (~200MB) and recompiling all Elm packages
- Triggers on push to main + hourly schedule (same as before)
- Deploys built `dist/` to Cloudflare Pages via `wrangler pages deploy`

### Setup required before merging
Add these repository secrets in GitHub Settings → Secrets:
1. **`CLOUDFLARE_API_TOKEN`** — Create at [Cloudflare Dashboard → API Tokens](https://dash.cloudflare.com/profile/api-tokens) with `Cloudflare Pages:Edit` permission
2. **`CLOUDFLARE_ACCOUNT_ID`** — Found in Cloudflare dashboard sidebar
3. **`CLOUDFLARE_PAGES_PROJECT_NAME`** — The project name in Cloudflare Pages (probably `transdimension` or similar)

Once secrets are set, you can also disable the "Build configuration" in Cloudflare Pages dashboard since GitHub Actions handles the build now.

Closes #529

## Test plan
- [ ] Add the three repository secrets
- [ ] Merge and verify the first GitHub Actions build succeeds
- [ ] Confirm site deploys correctly to Cloudflare Pages
- [ ] Verify the hourly scheduled rebuild works
- [ ] Disable Cloudflare Pages' own build (optional, to avoid double builds)