### PR TITLE
Cache Elm packages on Cloudflare and retry build on failure

### DIFF
--- a/.cloudflare/pages/build-cache-config.json
+++ b/.cloudflare/pages/build-cache-config.json
@@ -1,0 +1,3 @@
+{
+  "additionalCachePaths": ["elm-stuff"]
+}

--- a/scripts/set-build-dates.mjs
+++ b/scripts/set-build-dates.mjs
@@ -1,5 +1,6 @@
 // Compute FROM_DATE and TO_DATE at build time, then run the given command.
 // FROM_DATE = 1 month ago, TO_DATE = 6 months from now.
+// Retries on failure to handle transient network issues (e.g. Elm package registry timeouts).
 import { execSync } from "node:child_process";
 
 const now = new Date();
@@ -14,4 +15,20 @@ process.env.FROM_DATE = process.env.FROM_DATE || fmt(from);
 process.env.TO_DATE = process.env.TO_DATE || fmt(to);
 
 const command = process.argv.slice(2).join(" ") || "elm-constants && elm-pages build";
-execSync(command, { stdio: "inherit", env: process.env });
+const maxRetries = 3;
+
+for (let attempt = 1; attempt <= maxRetries; attempt++) {
+  try {
+    execSync(command, { stdio: "inherit", env: process.env });
+    break;
+  } catch (error) {
+    if (attempt < maxRetries) {
+      const delay = attempt * 30;
+      console.error(`Build attempt ${attempt}/${maxRetries} failed. Retrying in ${delay}s...`);
+      execSync(`sleep ${delay}`);
+    } else {
+      console.error(`Build failed after ${maxRetries} attempts.`);
+      process.exit(error.status || 1);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.cloudflare/pages/build-cache-config.json` to persist `elm-stuff` between Cloudflare Pages builds, avoiding redundant package downloads
- Adds retry logic (3 attempts with 30s/60s backoff) to the build script to handle transient Elm package registry timeouts

Closes #529

## Test plan
- [x] Local build passes
- [ ] Verify Cloudflare Pages build succeeds on merge
- [ ] Confirm `elm-stuff` is cached on subsequent builds (second build should skip package downloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)